### PR TITLE
v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
-### v0.4.2
+### v0.5.0
 
 - New Features
     - `Icicle\Socket\Datagram` classes and interfaces added to documentation and can now be used.
 
 - Changes
+    - The Loop facade class has been replaced by a set of functions defined in the `Icicle\Loop` namespace. Generally, calls to the Loop facade such as `Loop::run()` can be replaced with `Loop\run()` (using `Icicle\Loop` instead of `Icicle\Loop\Loop`). See the [Loop documentation](https://github.com/icicleio/Icicle/wiki/Loop) for more information.
+    - Static functions in `Icicle\Promise\Promise` have been replaced with functions defined in the `Icicle\Promise` namespace. Calls such as `Promise::resolve()` can be replace with `Promise\resolve()` (using `Icicle\Promise` instead of `Icicle\Promise\Promise`). See the [Promises documentation](https://github.com/icicleio/Icicle/wiki/Promises) for more information.
+    - Static functions in `Icicle\Coroutine\Coroutine` have been replaced with functions defined in the `Icicle\Coroutine` namespace. Like promises above, calls such as `Coroutine::async()` can be replace with `Coroutine\async()` (using `Icicle\Coroutine` instead of `Icicle\Coroutine\Coroutine`). See the [Coroutine documentation](https://github.com/icicleio/Icicle/wiki/Coroutine) for more information.
+    - Lazy promises should now be created with the function `Icicle\Promise\lazy()` instead of directly constructing a `LazyPromise` instance. `Icicle\Promise\LazyPromise` has been moved to `Icicle\Promise\Structures\LazyPromise` and should not be created directly, but rather is an implementation detail of `Icicle\Promise\lazy()`.
     - The promise returned from `Icicle\Socket\Server\Server::accept()` will no longer be rejected with an `AcceptException` if accepting the client fails. The timeout option was also removed from this method, as retrying after a failed accept would make the timeout unreliable.
     - Removed tests from distributions after updating other components to no longer depend on test classes from this package. Use the `--prefer-source` option when installing with Composer if you wish to have tests included.
 
@@ -17,14 +21,14 @@
 ### v0.4.1
 
 - Changes
-    - ~~Added tests back into distributions so users could verify their setup and so other components could use base test classes.~~ (Removed in v0.4.2)
+    - ~~Added tests back into distributions so users could verify their setup and so other components could use base test classes.~~ (Removed in v0.5.0)
 
 ---
 
 ### v0.4.0
 
 - New Features
-    - Process signals are now treated like other loop events and are represented by objects implementing `Icicle\Loop\Events\SignalInterface`. Use the `Icicle\Loop\Loop::signal()` method to create signal event objects. See the [documentation](//github.com/icicleio/Icicle/wiki/Loop#signal) for more information.
+    - Process signals are now treated like other loop events and are represented by objects implementing `Icicle\Loop\Events\SignalInterface`. Use the `Icicle\Loop\Loop::signal()` method to create signal event objects. See the [documentation](https://github.com/icicleio/Icicle/wiki/Loop#signal) for more information.
     - Added method `isEmpty()` to `Icicle\Loop\Loop` that determines if there are any events pending in the loop.
     - Support for unix sockets added to `Icicle\Socket\Client\Connector` by passing the file path as the first parameter and `null` for the port and adding `'protocol' => 'unix'` to the array of options.
     - Support for unix sockets also added to `Icicle\Socket\Server\ServerFactory` by passing the file path as the first parameter and `null` for the port and adding `'protocol' => 'unix'` to the array of options.
@@ -82,7 +86,7 @@
 ### v0.2.0
 
 - Increased minimum PHP version to 5.5 so external components can be fully compatible with Icicle and make use of Coroutines. This will avoid compatibility confusion and allow for faster development of additional components.
-- Refactored loop implementations to make use of [Managers](../src/Loop/Events/Manager). These interfaces and classes are implementation details of each loop, as these objects are never revealed to the user. However, this change allowed `Icicle\Loop\LoopInterface` to be much simpler (as event objects now interact with the manager object instead of the loop object) and exposes only methods that should be publicly available.
+- Refactored loop implementations to make use of [Managers](https://github.com/icicleio/icicle/tree/master/src/Loop/Events/Manager). These interfaces and classes are implementation details of each loop, as these objects are never revealed to the user. However, this change allowed `Icicle\Loop\LoopInterface` to be much simpler (as event objects now interact with the manager object instead of the loop object) and exposes only methods that should be publicly available.
 - `Icicle\Loop\Events\PollInterface` and `Icicle\Loop\Events\AwaitInterface` have been eliminated in favor of a single object, `Icicle\Loop\Events\SocketEventInterface`. `Icicle\Loop\Loop::poll()` and `Icicle\Loop\Loop::await()` (and the corresponding methods in objects implementing `Icicle\Loop\LoopInterface`) both return an object implementing this interface. The mode (read or write) the returned object uses when listening on the given socket depends on which method created the `Icicle\Loop\Events\SocketEventInterface` object.
 - Reorganized the Socket component into more specific namespaces under `Icicle\Socket`: `Client`, `Datagram`, `Server`, and `Stream`.
 - Removed static constructors from Server, Datagram, and Client classes, replacing them with interfaced factories.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Icicle uses [Coroutines](#coroutines) built with [Promises](#promises) to facili
 [![@icicleio on Twitter](https://img.shields.io/badge/twitter-%40icicleio-5189c7.svg?style=flat-square)](https://twitter.com/icicleio)
 [![Build Status](https://img.shields.io/travis/icicleio/Icicle/master.svg?style=flat-square)](https://travis-ci.org/icicleio/Icicle)
 [![Coverage Status](https://img.shields.io/coveralls/icicleio/Icicle.svg?style=flat-square)](https://coveralls.io/r/icicleio/Icicle)
-[![Semantic Version](https://img.shields.io/badge/semver-v0.4.2-yellow.svg?style=flat-square)](http://semver.org)
+[![Semantic Version](https://img.shields.io/badge/semver-v0.5.0-yellow.svg?style=flat-square)](http://semver.org)
 [![Apache 2 License](https://img.shields.io/packagist/l/icicleio/Icicle.svg?style=flat-square)](LICENSE)
 
 [![Join the chat at https://gitter.im/icicleio/Icicle](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/icicleio/Icicle)
@@ -22,9 +22,9 @@ Icicle uses [Coroutines](#coroutines) built with [Promises](#promises) to facili
 
 #### Available Components
 
-- [HTTP](//github.com/icicleio/Http): Asynchronous HTTP server and client (under development).
-- [DNS](//github.com/icicleio/Dns): Asynchronous DNS resolver and connector.
-- [React Adaptor](//github.com/icicleio/ReactAdaptor): Adapts the event loop and promises of Icicle to interfaces compatible with components built for React.
+- [HTTP](https://github.com/icicleio/Http): Asynchronous HTTP server and client (under development).
+- [DNS](https://github.com/icicleio/Dns): Asynchronous DNS resolver and connector.
+- [React Adaptor](https://github.com/icicleio/ReactAdaptor): Adapts the event loop and promises of Icicle to interfaces compatible with components built for React.
 
 ##### Requirements
 
@@ -46,7 +46,7 @@ You can also manually edit `composer.json` to add Icicle as a project requiremen
 // composer.json
 {
     "require": {
-        "icicleio/icicle": "0.4.*"
+        "icicleio/icicle": "0.5.*"
     }
 }
 ```
@@ -72,12 +72,12 @@ The `Icicle\Promise\PromiseInterface::then(callable $onFulfilled = null, callabl
 
 The `Icicle\Promise\PromiseInterface::done(callable $onFulfilled = null, callable $onRejected = null)` method registers callbacks that should either consume promised values or handle errors. No value is returned from `done()`. Values returned by callbacks registered using `done()` are ignored and exceptions thrown from callbacks are re-thrown in an uncatchable way.
 
-*[More on using callbacks to interact with promises...](//github.com/icicleio/Icicle/wiki/Promises#interacting-with-promises)*
+*[More on using callbacks to interact with promises...](https://github.com/icicleio/Icicle/wiki/Promises#interacting-with-promises)*
 
 ```php
 use Icicle\Dns\Executor\Executor;
 use Icicle\Dns\Resolver\Resolver;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Socket\Client\ClientInterface;
 use Icicle\Socket\Client\Connector;
 
@@ -102,15 +102,15 @@ $promise2->done(
     }
 );
 
-Loop::run();
+Loop\run();
 ```
 
-The example above uses the [DNS component](//github.com/icicleio/Dns) to resolve the IP address for a domain, then connect to the resolved IP address. The `resolve()` method of `$resolver` and the `connect()` method of `$connector` both return promises. `$promise1` created by `resolve()` will either be fulfilled or rejected:
+The example above uses the [DNS component](https://github.com/icicleio/Dns) to resolve the IP address for a domain, then connect to the resolved IP address. The `resolve()` method of `$resolver` and the `connect()` method of `$connector` both return promises. `$promise1` created by `resolve()` will either be fulfilled or rejected:
 
 - If `$promise1` is fulfilled, the callback function registered in the call to `$promise1->then()` is executed, using the fulfillment value of `$promise1` as the argument to the function. The callback function then returns the promise from `connect()`. The resolution of `$promise2` will then be determined by the resolution of this returned promise (`$promise2` will adopt the state of the promise returned by `connect()`).
 - If `$promise1` is rejected, `$promise2` is rejected since no `$onRejected` callback was registered in the call to `$promise1->then()`
 
-*[More on promise resolution and propagation...](//github.com/icicleio/Icicle/wiki/Promises#resolution-and-propagation)*
+*[More on promise resolution and propagation...](https://github.com/icicleio/Icicle/wiki/Promises#resolution-and-propagation)*
 
 ##### Brief overview of promise API features
 
@@ -121,7 +121,7 @@ The example above uses the [DNS component](//github.com/icicleio/Dns) to resolve
 - Support for promise cancellation.
 - Methods to convert synchronous functions or callback-based functions into functions accepting and returning promises.
 
-**[Promise API documentation](//github.com/icicleio/Icicle/wiki/Promises)**
+**[Promise API documentation](https://github.com/icicleio/Icicle/wiki/Promises)**
 
 ## Coroutines
 
@@ -137,7 +137,7 @@ The example below creates an `Icicle\Coroutine\Coroutine` instance from a functi
 use Icicle\Coroutine\Coroutine;
 use Icicle\Dns\Executor\Executor;
 use Icicle\Dns\Resolver\Resolver;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Socket\Client\Connector;
 
 $generator = function () {
@@ -160,44 +160,42 @@ $generator = function () {
 
 $coroutine = new Coroutine($generator());
 
-Loop::run();
+Loop\run();
 ```
 
 The example above does the same thing as the example in the section on [promises](#promises) above, but instead uses a coroutine to **structure asynchronous code like synchronous code**. Fulfillment values of promises are accessed through simple variable assignments and exceptions used to reject promises are caught using a try/catch block, rather than creating and registering callback functions to each promise.
 
 An `Icicle\Coroutine\Coroutine` object is also a [promise](#promises), implementing `Icicle\Promise\PromiseInterface`. The promise is fulfilled with the last value yielded from the generator (or fulfillment value of the last yielded promise) or rejected if an exception is thrown from the generator. **A coroutine may then yield other coroutines, suspending execution of the calling coroutine until the yielded coroutine has completed execution.** If a coroutine yields a `Generator`, it will automatically be converted to a `Icicle\Coroutine\Coroutine` and handled in the same way as a yielded coroutine.
 
-**[Coroutine API documentation](//github.com/icicleio/Icicle/wiki/Coroutines)**
+**[Coroutine API documentation](https://github.com/icicleio/Icicle/wiki/Coroutines)**
 
 ## Loop
 
 The event loop schedules functions, runs timers, handles signals, and polls sockets for pending reads and available writes. There are several event loop implementations available depending on what PHP extensions are available. The `Icicle\Loop\SelectLoop` class uses only core PHP functions, so it will work on any PHP installation, but is not as performant as some of the other available implementations. All event loops implement `Icicle\Loop\LoopInterface` and provide the same features.
 
-The event loop should be accessed via the static methods of the `Icicle\Loop\Loop` facade class. The `Icicle\Loop\Loop::init()` method allows a specific or custom implementation of `Icicle\Loop\LoopInterface` to be used as the event loop.
+The event loop should be accessed via functions defined in the `Icicle\Loop` namespace. If a program requires a specific or custom event loop implementation, `Icicle\Loop\loop()` can be called with an instance of `Icicle\Loop\LoopInterface` before any other loop functions to use that instance as the event loop.
 
-The `Icicle\Loop\Loop::run()` method runs the event loop and will not return until the event loop is stopped or no events are pending in the loop.
+The `Icicle\Loop\run()` function runs the event loop and will not return until the event loop is stopped or no events are pending in the loop.
 
-The following code demonstrates how timers can be created to execute functions after a number of seconds elapses using the `Icicle\Loop\Loop::timer()` method.
+The following code demonstrates how timers can be created to execute functions after a number of seconds elapses using the `Icicle\Loop\timer()` function.
 
 ```php
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 
-// Note that the Loop class is a facade to an instance of Icicle\Loop\LoopInterface (see description above).
-
-Loop::timer(1, function () { // Executed after 1 second.
+Loop\timer(1, function () { // Executed after 1 second.
 	echo "First.\n";
-	Loop::timer(1.5, function () { // Executed after 1.5 seconds.
+	Loop\timer(1.5, function () { // Executed after 1.5 seconds.
 	    echo "Second.\n";
 	});
 	echo "Third.\n";
-	Loop::timer(0.5, function () { // Executed after 0.5 seconds.
+	Loop\timer(0.5, function () { // Executed after 0.5 seconds.
 		echo "Fourth.\n";
 	});
 	echo "Fifth.\n";
 });
 
 echo "Starting event loop.\n";
-Loop::run();
+Loop\run();
 ```
 
 The above code will output:
@@ -211,7 +209,7 @@ Fourth.
 Second.
 ```
 
-**[Loop API documentation](//github.com/icicleio/Icicle/wiki/Loop)**
+**[Loop API documentation](https://github.com/icicleio/Icicle/wiki/Loop)**
 
 ## Streams
 
@@ -221,7 +219,7 @@ Streams represent a common promise-based API that may be implemented by classes 
 - `Icicle\Stream\WritableStreamInterface`: Interface to be used by streams that are only writable.
 - `Icicle\Stream\DuplexStreamInterface`: Interface to be used by streams that are readable and writable. Extends both `Icicle\Stream\ReadableStreamInterface` and `Icicle\Stream\WritableStreamInterface`.
 
-**[Streams API documentation](//github.com/icicleio/Icicle/wiki/Streams)**
+**[Streams API documentation](https://github.com/icicleio/Icicle/wiki/Streams)**
 
 ## Sockets
 
@@ -230,7 +228,7 @@ The socket component implements network sockets as promise-based streams, server
 The example below implements HTTP server that responds to any request with `Hello world!` implemented using the promise-based server and client provided by the Socket component.
 
 ```php
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Socket\Client\ClientInterface;
 use Icicle\Socket\Server\ServerFactory;
 
@@ -256,14 +254,14 @@ $server->accept()->done($handler, $error);
 
 echo "Server listening on {$server->getAddress()}:{$server->getPort()}\n";
 
-Loop::run();
+Loop\run();
 ```
 
 The example below shows the same HTTP server as above, instead implemented using a coroutine.
 
 ```php
 use Icicle\Coroutine\Coroutine;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Socket\Client\ClientInterface;
 use Icicle\Socket\Server\ServerInterface;
 use Icicle\Socket\Server\ServerFactory;
@@ -296,10 +294,10 @@ $generator = function (ServerInterface $server) {
 
 $coroutine = new Coroutine($generator($server));
 
-Loop::run();
+Loop\run();
 ```
 
-**[Sockets API documentation](//github.com/icicleio/Icicle/wiki/Sockets)**
+**[Sockets API documentation](https://github.com/icicleio/Icicle/wiki/Sockets)**
 
 ## Example
 
@@ -307,7 +305,7 @@ The example below shows how the components outlined above can be combined to qui
 
 ```php
 use Icicle\Coroutine\Coroutine;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Socket\Client\ClientInterface;
 use Icicle\Socket\Server\ServerInterface;
 use Icicle\Socket\Server\ServerFactory;
@@ -351,5 +349,5 @@ $generator = function (ServerInterface $server) {
 
 $coroutine = new Coroutine($generator($server));
 
-Loop::run();
+Loop\run();
 ```

--- a/composer.json
+++ b/composer.json
@@ -37,14 +37,19 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.4-dev",
-            "dev-development": "0.5-dev"
+            "dev-master": "0.5-dev",
+            "dev-development": "0.6-dev"
         }
     },
     "autoload": {
         "psr-4": {
             "Icicle\\": "src"
-        }
+        },
+        "files": [
+            "src/Coroutine/functions.php",
+            "src/Loop/functions.php",
+            "src/Promise/functions.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/examples/chat.php
+++ b/examples/chat.php
@@ -3,18 +3,18 @@
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-use Icicle\Coroutine\Coroutine;
-use Icicle\Loop\Loop;
+use Icicle\Coroutine;
+use Icicle\Loop;
 use Icicle\Socket\Client\ClientInterface;
 use Icicle\Socket\Server\ServerInterface;
 use Icicle\Socket\Server\ServerFactory;
 
 // Connect using `nc localhost 60000`.
 
-$coroutine = Coroutine::call(function (ServerInterface $server) {
+$coroutine = Coroutine\create(function (ServerInterface $server) {
     $clients = new SplObjectStorage();
     
-    $handler = Coroutine::async(function (ClientInterface $client) use (&$clients) {
+    $handler = Coroutine\async(function (ClientInterface $client) use (&$clients) {
         $clients->attach($client);
         $name = $client->getRemoteAddress() . ':' . $client->getRemotePort();
         
@@ -56,5 +56,5 @@ $coroutine = Coroutine::call(function (ServerInterface $server) {
     }
 }, (new ServerFactory())->create('127.0.0.1', 60000));
 
-Loop::run();
+Loop\run();
 

--- a/examples/datagram.php
+++ b/examples/datagram.php
@@ -4,7 +4,7 @@
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 use Icicle\Coroutine\Coroutine;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Socket\Datagram\DatagramInterface;
 use Icicle\Socket\Datagram\DatagramFactory;
 
@@ -29,4 +29,4 @@ $generator = function (DatagramInterface $datagram) {
 
 $coroutine = new Coroutine($generator($datagram));
 
-Loop::run();
+Loop\run();

--- a/examples/echo.php
+++ b/examples/echo.php
@@ -4,7 +4,7 @@
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 use Icicle\Coroutine\Coroutine;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Socket\Client\ClientInterface;
 use Icicle\Socket\Server\ServerFactory;
 use Icicle\Socket\Server\Server;
@@ -46,4 +46,4 @@ $generator = function (Server $server) {
 
 $coroutine = new Coroutine($generator((new ServerFactory())->create('127.0.0.1', 60000)));
 
-Loop::run();
+Loop\run();

--- a/examples/http.php
+++ b/examples/http.php
@@ -4,7 +4,7 @@
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 use Icicle\Coroutine\Coroutine;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Socket\Client\ClientInterface;
 use Icicle\Socket\Server\ServerInterface;
 use Icicle\Socket\Server\ServerFactory;
@@ -51,4 +51,4 @@ $coroutine->cleanup(function () use ($server) {
 
 echo "Server started.\n";
 
-Loop::run();
+Loop\run();

--- a/examples/stream.php
+++ b/examples/stream.php
@@ -3,7 +3,7 @@
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Stream\Stream;
 
 $stream = new Stream();
@@ -17,4 +17,4 @@ $stream
         echo $data; // Echos "This is just a test."
     });
 
-Loop::run();
+Loop\run();

--- a/src/Coroutine/Coroutine.php
+++ b/src/Coroutine/Coroutine.php
@@ -3,32 +3,23 @@ namespace Icicle\Coroutine;
 
 use Exception;
 use Generator;
-use Icicle\Coroutine\Exception\InvalidCallableException;
 use Icicle\Coroutine\Exception\InvalidGeneratorException;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Promise\Promise;
 use Icicle\Promise\PromiseInterface;
-use Icicle\Promise\PromiseTrait;
 
 /**
  * This class implements cooperative coroutines using Generators. Coroutines should yield promises to pause execution
  * of the coroutine until the promise has resolved. If the promise is fulfilled, the fulfillment value is sent to the
  * generator. If the promise is rejected, the rejection exception is thrown into the generator.
  */
-class Coroutine implements CoroutineInterface
+class Coroutine extends Promise implements CoroutineInterface
 {
-    use PromiseTrait;
-    
     /**
      * @var \Generator|null
      */
     private $generator;
-    
-    /**
-     * @var \Icicle\Promise\Promise
-     */
-    private $promise;
-    
+
     /**
      * @var \Closure|null
      */
@@ -37,7 +28,7 @@ class Coroutine implements CoroutineInterface
     /**
      * @var \Closure|null
      */
-    private $pitch;
+    private $capture;
     
     /**
      * @var mixed
@@ -61,7 +52,7 @@ class Coroutine implements CoroutineInterface
     {
         $this->generator = $generator;
         
-        $this->promise = new Promise(
+        parent::__construct(
             function ($resolve, $reject) {
                 /**
                  * @param   mixed $value The value to send to the Generator.
@@ -69,7 +60,7 @@ class Coroutine implements CoroutineInterface
                  */
                 $this->worker = function ($value = null, Exception $exception = null) use ($resolve, $reject) {
                     static $initial = true;
-                    if (!$this->promise->isPending()) { // Coroutine may have been cancelled.
+                    if (!$this->isPending()) { // Coroutine may have been cancelled.
                         return;
                     }
                     
@@ -99,13 +90,13 @@ class Coroutine implements CoroutineInterface
                         }
                         
                         if ($this->current instanceof Generator) {
-                            $this->current = new static($this->current);
+                            $this->current = new self($this->current);
                         }
                         
                         if ($this->current instanceof PromiseInterface) {
-                            $this->current->done($this->worker, $this->pitch);
+                            $this->current->done($this->worker, $this->capture);
                         } else {
-                            Loop::schedule($this->worker, $this->current);
+                            Loop\schedule($this->worker, $this->current);
                         }
                     } catch (Exception $exception) {
                         $reject($exception);
@@ -116,13 +107,13 @@ class Coroutine implements CoroutineInterface
                 /**
                  * @param   \Exception $exception Exception to be thrown into the generator.
                  */
-                $this->pitch = function (Exception $exception) {
+                $this->capture = function (Exception $exception) {
                     if (null !== ($worker = $this->worker)) { // Coroutine may have been closed.
                         $worker(null, $exception);
                     }
                 };
                 
-                Loop::schedule($this->worker);
+                Loop\schedule($this->worker);
             },
             function (Exception $exception) {
                 try {
@@ -147,7 +138,7 @@ class Coroutine implements CoroutineInterface
     private function close()
     {
         $this->generator = null;
-        $this->pitch = null;
+        $this->capture = null;
         $this->worker = null;
         $this->current = null;
         
@@ -167,14 +158,14 @@ class Coroutine implements CoroutineInterface
      */
     public function resume()
     {
-        if ($this->promise->isPending() && $this->isPaused()) {
+        if ($this->isPending() && $this->isPaused()) {
             $this->paused = false;
             
             if ($this->ready) {
                 if ($this->current instanceof PromiseInterface) {
-                    $this->current->done($this->worker, $this->pitch);
+                    $this->current->done($this->worker, $this->capture);
                 } else {
-                    Loop::schedule($this->worker, $this->current);
+                    Loop\schedule($this->worker, $this->current);
                 }
                 
                 $this->ready = false;
@@ -188,165 +179,5 @@ class Coroutine implements CoroutineInterface
     public function isPaused()
     {
         return $this->paused;
-    }
-    
-    /**
-     * @inheritdoc
-     */
-    public function cancel($reason = null)
-    {
-        $this->promise->cancel($reason);
-    }
-    
-    /**
-     * @inheritdoc
-     */
-    public function then(callable $onFulfilled = null, callable $onRejected = null)
-    {
-        return $this->promise->then($onFulfilled, $onRejected);
-    }
-    
-    /**
-     * @inheritdoc
-     */
-    public function done(callable $onFulfilled = null, callable $onRejected = null)
-    {
-        $this->promise->done($onFulfilled, $onRejected);
-    }
-    
-    /**
-     * @inheritdoc
-     */
-    public function timeout($timeout, $reason = null)
-    {
-        return $this->promise->timeout($timeout, $reason);
-    }
-    
-    /**
-     * @inheritdoc
-     */
-    public function delay($time)
-    {
-        return $this->promise->delay($time);
-    }
-    
-    /**
-     * @inheritdoc
-     */
-    public function isPending()
-    {
-        return $this->promise->isPending();
-    }
-    
-    /**
-     * @inheritdoc
-     */
-    public function isFulfilled()
-    {
-        return $this->promise->isFulfilled();
-    }
-    
-    /**
-     * @inheritdoc
-     */
-    public function isRejected()
-    {
-        return $this->promise->isRejected();
-    }
-    
-    /**
-     * @inheritdoc
-     */
-    public function getResult()
-    {
-        return $this->promise->getResult();
-    }
-    
-    /**
-     * @inheritdoc
-     */
-    public function unwrap()
-    {
-        return $this->promise->unwrap();
-    }
-    
-    /**
-     * @param   callable $worker
-     *
-     * @return  callable
-     */
-    public static function async(callable $worker)
-    {
-        /**
-         * @param   mixed ...$args
-         *
-         * @return  \Icicle\Coroutine\Coroutine
-         *
-         * @throws  \Icicle\Coroutine\Exception\InvalidCallableException If the callable throws an exception or does
-         *          not return a Generator.
-         */
-        return function (/* ...$args */) use ($worker) {
-            return static::create($worker, func_get_args());
-        };
-    }
-    
-    /**
-     * @param   callable $worker
-     * @param   mixed ...$args
-     *
-     * @return  \Icicle\Coroutine\Coroutine
-     *
-     * @throws  \Icicle\Coroutine\Exception\InvalidCallableException If the callable throws an exception or does not
-     *          return a Generator.
-     */
-    public static function call(callable $worker /* , ...$args */)
-    {
-        $args = array_slice(func_get_args(), 1);
-        
-        return static::create($worker, $args);
-    }
-    
-    /**
-     * @param   callable $worker
-     * @param   mixed[] $args
-     *
-     * @return  \Icicle\Coroutine\Coroutine
-     *
-     * @throws  \Icicle\Coroutine\Exception\InvalidCallableException If the callable throws an exception or does not
-     *          return a Generator.
-     */
-    public static function create(callable $worker, array $args = null)
-    {
-        try {
-            if (empty($args)) {
-                $generator = $worker();
-            } else {
-                $generator = call_user_func_array($worker, $args);
-            }
-        } catch (Exception $exception) {
-            throw new InvalidCallableException('The callable threw an exception.', $worker, $exception);
-        }
-        
-        if (!$generator instanceof Generator) {
-            throw new InvalidCallableException('The callable did not produce a Generator.', $worker);
-        }
-        
-        return new static($generator);
-    }
-    
-    /**
-     * @coroutine
-     *
-     * @param   float $time Time to sleep in seconds.
-     *
-     * @return  \Generator
-     *
-     * @resolve float Actual time slept in seconds.
-     */
-    public static function sleep($time)
-    {
-        $start = (yield Promise::resolve(microtime(true))->delay($time));
-        
-        yield microtime(true) - $start;
     }
 }

--- a/src/Coroutine/functions.php
+++ b/src/Coroutine/functions.php
@@ -1,0 +1,75 @@
+<?php
+namespace Icicle\Coroutine;
+
+use Icicle\Coroutine\Exception\InvalidCallableException;
+use Icicle\Promise;
+
+if (!function_exists(__NAMESPACE__ . '\async')) {
+    /**
+     * @param   callable $worker
+     *
+     * @return  callable
+     */
+    function async(callable $worker)
+    {
+        /**
+         * @param   mixed ...$args
+         *
+         * @return  \Icicle\Coroutine\Coroutine
+         *
+         * @throws  \Icicle\Coroutine\Exception\InvalidCallableException If the callable throws an exception or does
+         *          not return a Generator.
+         */
+        return function (/* ...$args */) use ($worker) {
+            $args = func_get_args();
+            array_unshift($args, $worker);
+            return call_user_func_array(__NAMESPACE__ . '\create', $args);
+        };
+    }
+
+    /**
+     * @param   callable $worker
+     * @param   mixed ...$args
+     *
+     * @return  \Icicle\Coroutine\Coroutine
+     *
+     * @throws  \Icicle\Coroutine\Exception\InvalidCallableException If the callable throws an exception or does not
+     *          return a Generator.
+     */
+    function create(callable $worker /* , ...$args */)
+    {
+        $args = array_slice(func_get_args(), 1);
+
+        try {
+            if (empty($args)) {
+                $generator = $worker();
+            } else {
+                $generator = call_user_func_array($worker, $args);
+            }
+        } catch (\Exception $exception) {
+            throw new InvalidCallableException('The callable threw an exception.', $worker, $exception);
+        }
+
+        if (!$generator instanceof \Generator) {
+            throw new InvalidCallableException('The callable did not return a Generator.', $worker);
+        }
+
+        return new Coroutine($generator);
+    }
+
+    /**
+     * @coroutine
+     *
+     * @param   float $time Time to sleep in seconds.
+     *
+     * @return  \Generator
+     *
+     * @resolve float Actual time slept in seconds.
+     */
+    function sleep($time)
+    {
+        $start = (yield Promise\resolve(microtime(true))->delay($time));
+
+        yield microtime(true) - $start;
+    }
+}

--- a/src/Loop/LoopInterface.php
+++ b/src/Loop/LoopInterface.php
@@ -101,13 +101,13 @@ interface LoopInterface
      * Creates a timer object connected to the loop.
      *
      * @param   int|float $interval
-     * @param   callable $callback
      * @param   bool $periodic
+     * @param   callable $callback
      * @param   array $args
      *
      * @return  \Icicle\Loop\Events\TimerInterface
      */
-    public function timer($interval, $periodic = false, callable $callback, array $args = null);
+    public function timer($interval, $periodic, callable $callback, array $args = null);
     
     /**
      * Creates an immediate object connected to the loop.

--- a/src/Loop/functions.php
+++ b/src/Loop/functions.php
@@ -5,7 +5,7 @@ use Icicle\Loop\Exception\InitializedException;
 
 if (!function_exists(__NAMESPACE__ . '\loop')) {
     /**
-     * Returns the global event loop.
+     * Returns the active event loop. Can be used to set the active event loop if the event loop has not been accessed.
      *
      * @param   \Icicle\Loop\LoopInterface|null $loop
      * 
@@ -15,15 +15,11 @@ if (!function_exists(__NAMESPACE__ . '\loop')) {
     {
         static $instance;
 
-        // @codeCoverageIgnoreStart
-        if (null !== $loop) {
-            if (null !== $instance) {
-                throw new InitializedException('The loop has already been initialized.');
-            }
-            $instance = $loop;
-        } elseif (null === $instance) {
-            $instance = create();
-        } // @codeCoverageIgnoreEnd
+        if (null === $instance) {
+            $instance = $loop ?: create();
+        } elseif (null !== $loop) {
+            throw new InitializedException('The loop has already been initialized.');
+        }
 
         return $instance;
     }
@@ -59,7 +55,7 @@ if (!function_exists(__NAMESPACE__ . '\loop')) {
 
         loop()->schedule($callback, $args);
     }
-    
+
     /**
      * Sets the maximum number of callbacks set with nextTick() that will be executed per tick.
      *
@@ -71,7 +67,7 @@ if (!function_exists(__NAMESPACE__ . '\loop')) {
     {
         return loop()->maxScheduleDepth($depth);
     }
-    
+
     /**
      * Executes a single tick of the event loop.
      *
@@ -81,7 +77,7 @@ if (!function_exists(__NAMESPACE__ . '\loop')) {
     {
         loop()->tick($blocking);
     }
-    
+
     /**
      * Runs the event loop, dispatching I/O events, timers, etc.
      *
@@ -93,7 +89,7 @@ if (!function_exists(__NAMESPACE__ . '\loop')) {
     {
         return loop()->run();
     }
-    
+
     /**
      * Determines if the event loop is running.
      *
@@ -103,7 +99,7 @@ if (!function_exists(__NAMESPACE__ . '\loop')) {
     {
         return loop()->isRunning();
     }
-    
+
     /**
      * Stops the event loop.
      */
@@ -121,7 +117,7 @@ if (!function_exists(__NAMESPACE__ . '\loop')) {
     {
         return loop()->isEmpty();
     }
-    
+
     /**
      * @param   resource $socket Stream socket resource.
      * @param   callable $callback Callback to be invoked when data is available on the socket.
@@ -132,7 +128,7 @@ if (!function_exists(__NAMESPACE__ . '\loop')) {
     {
         return loop()->poll($socket, $callback);
     }
-    
+
     /**
      * @param   resource $socket Stream socket resource.
      * @param   callable $callback Callback to be invoked when the socket is available to write.
@@ -143,7 +139,7 @@ if (!function_exists(__NAMESPACE__ . '\loop')) {
     {
         return loop()->await($socket, $callback);
     }
-    
+
     /**
      * @param   float|int $interval Number of seconds before the callback is invoked.
      * @param   callable $callback Function to invoke when the timer expires.
@@ -157,7 +153,7 @@ if (!function_exists(__NAMESPACE__ . '\loop')) {
 
         return loop()->timer($interval, false, $callback, $args);
     }
-    
+
     /**
      * @param   float|int $interval Number of seconds between invocations of the callback.
      * @param   callable $callback Function to invoke when the timer expires.
@@ -171,7 +167,7 @@ if (!function_exists(__NAMESPACE__ . '\loop')) {
 
         return loop()->timer($interval, true, $callback, $args);
     }
-    
+
     /**
      * @param   callable $callback Function to invoke when no other active events are available.
      * @param   mixed ...$args Arguments to pass to the callback function.
@@ -195,7 +191,7 @@ if (!function_exists(__NAMESPACE__ . '\loop')) {
     {
         return loop()->signal($signo, $callback);
     }
-    
+
     /**
      * Determines if signal handling is enabled.
      *
@@ -213,7 +209,7 @@ if (!function_exists(__NAMESPACE__ . '\loop')) {
     {
         loop()->clear();
     }
-    
+
     /**
      * Performs any reinitializing necessary after forking.
      */

--- a/src/Promise/Promise.php
+++ b/src/Promise/Promise.php
@@ -2,10 +2,8 @@
 namespace Icicle\Promise;
 
 use Exception;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Promise\Exception\CancelledException;
-use Icicle\Promise\Exception\LogicException;
-use Icicle\Promise\Exception\MultiReasonException;
 use Icicle\Promise\Exception\TimeoutException;
 use Icicle\Promise\Exception\TypeException;
 use Icicle\Promise\Exception\UnresolvedException;
@@ -137,7 +135,7 @@ class Promise implements PromiseInterface
         
         ++$this->children;
         
-        return new static(
+        return new self(
             function ($resolve, $reject) use ($onFulfilled, $onRejected) {
                 if (null !== $onFulfilled) {
                     $this->onFulfilled->push(function ($value) use ($resolve, $reject, $onFulfilled) {
@@ -168,7 +166,7 @@ class Promise implements PromiseInterface
                 }
             },
             function (Exception $exception) {
-                Loop::schedule(function () use ($exception) {
+                Loop\schedule(function () use ($exception) {
                     if (0 === --$this->children) {
                         $this->cancel($exception);
                     }
@@ -229,9 +227,9 @@ class Promise implements PromiseInterface
         
         ++$this->children;
         
-        return new static(
+        return new self(
             function ($resolve) use (&$timer, $timeout, $reason) {
-                $timer = Loop::timer($timeout, function () use ($reason) {
+                $timer = Loop\timer($timeout, function () use ($reason) {
                     if (!$reason instanceof Exception) {
                         $reason = new TimeoutException($reason);
                     }
@@ -249,7 +247,7 @@ class Promise implements PromiseInterface
             function (Exception $exception) use (&$timer) {
                 $timer->stop();
 
-                Loop::schedule(function () use ($exception) {
+                Loop\schedule(function () use ($exception) {
                     if (0 === --$this->children) {
                         $this->cancel($exception);
                     }
@@ -269,10 +267,10 @@ class Promise implements PromiseInterface
         
         ++$this->children;
         
-        return new static(
+        return new self(
             function ($resolve) use (&$timer, $time) {
                 $this->onFulfilled->push(function () use (&$timer, $time, $resolve) {
-                    $timer = Loop::timer($time, function () use ($resolve) {
+                    $timer = Loop\timer($time, function () use ($resolve) {
                         $resolve($this->result);
                     });
                 });
@@ -286,7 +284,7 @@ class Promise implements PromiseInterface
                     $timer->stop();
                 }
 
-                Loop::schedule(function () use ($exception) {
+                Loop\schedule(function () use ($exception) {
                     if (0 === --$this->children) {
                         $this->cancel($exception);
                     }
@@ -345,419 +343,5 @@ class Promise implements PromiseInterface
         }
         
         return $this;
-    }
-    
-    /**
-     * Return a promise using the given value. There are two possible outcomes depending on the type of the passed value:
-     * (1) PromiseInterface: The promise is returned without modification.
-     * (2) All other types: A fulfilled promise is returned using the given value as the result.
-     *
-     * @param   mixed $value
-     *
-     * @return  PromiseInterface
-     */
-    public static function resolve($value = null)
-    {
-        if ($value instanceof PromiseInterface) {
-            return $value;
-        }
-        
-        return new FulfilledPromise($value);
-    }
-    
-    /**
-     * Create a new rejected promise using the given reason.
-     *
-     * @param   mixed $reason
-     *
-     * @return  PromiseInterface
-     */
-    public static function reject($reason = null)
-    {
-        return new RejectedPromise($reason);
-    }
-    
-    /**
-     * Wraps the given callable $worker in a promise aware function that takes the same number of arguments as $worker,
-     * but those arguments may be promises for the future argument value or just values. The returned function will
-     * return a promise for the return value of $worker and will never throw. The $worker function will not be called
-     * until each promise given as an argument is fulfilled. If any promise provided as an argument rejects, the promise
-     * returned by the returned function will be rejected for the same reason. The promise is fulfilled with the return
-     * value of $worker or rejected if $worker throws.
-     *
-     * @param   callable $worker
-     *
-     * @return  callable
-     */
-    public static function lift(callable $worker)
-    {
-        /**
-         * @param   mixed ...$args Promises or values.
-         *
-         * @return  \Icicle\Promise\PromiseInterface
-         */
-        return function (/* ...$args */) use ($worker) {
-            return static::join(func_get_args())->splat($worker);
-        };
-    }
-    
-    /**
-     * Transforms a function that takes a callback into a function that returns a promise. The promise is fulfilled with 
-     * an array of the parameters that would have been passed to the callback function.
-     *
-     * @param   callable $worker Function that normally accepts a callback.
-     * @param   int $index Position of callback in $worker argument list (0-indexed).
-     *
-     * @return  callable
-     */
-    public static function promisify(callable $worker, $index = 0)
-    {
-        return function (/* ...$args */) use ($worker, $index) {
-            $args = func_get_args();
-            
-            return new static(function ($resolve) use ($worker, $index, $args) {
-                $callback = function (/* ...$args */) use ($resolve) {
-                    $resolve(func_get_args());
-                };
-                
-                if (count($args) < $index) {
-                    throw new LogicException('Too few arguments given to function.');
-                }
-                
-                array_splice($args, $index, 0, [$callback]);
-                
-                call_user_func_array($worker, $args);
-            });
-        };
-    }
-
-    /**
-     * Adapts any object with a then(callable $onFulfilled, callable $onRejected) method to a promise usable by
-     * components depending on promises implementing PromiseInterface.
-     *
-     * @param   object $thenable Object with a then() method.
-     *
-     * @return  PromiseInterface Promise resolved by the $thenable object.
-     */
-    public static function adapt($thenable)
-    {
-        if (!is_object($thenable) || !method_exists($thenable, 'then')) {
-            return Promise::reject(new TypeException('Must provide an object with a then() method.'));
-        }
-
-        return new static(function ($resolve, $reject) use ($thenable) {
-            $thenable->then($resolve, $reject);
-        });
-    }
-
-    /**
-     * Returns a promise that is resolved when all promises are resolved. The returned promise will not reject by itself
-     * (only if cancelled). Returned promise is fulfilled with an array of resolved promises, with keys identical and
-     * corresponding to the original given array.
-     *
-     * @param   mixed[] $promises Promises or values (passed through resolve() to create promises).
-     *
-     * @return  \Icicle\Promise\PromiseInterface
-     */
-    public static function settle(array $promises)
-    {
-        if (empty($promises)) {
-            return static::resolve([]);
-        }
-        
-        return new static(function ($resolve) use ($promises) {
-            $pending = count($promises);
-            
-            $after = function () use (&$promises, &$pending, $resolve) {
-                if (0 === --$pending) {
-                    $resolve($promises);
-                }
-            };
-            
-            foreach ($promises as &$promise) {
-                $promise = static::resolve($promise);
-                $promise->done($after, $after);
-            }
-        });
-    }
-    
-    /**
-     * Returns a promise that is fulfilled when all promises are fulfilled, and rejected if any promise is rejected.
-     * Returned promise is fulfilled with an array of values used to fulfill each contained promise, with keys
-     * corresponding to the array of promises.
-     *
-     * @param   mixed[] $promises Promises or values (passed through resolve() to create promises).
-     *
-     * @return  \Icicle\Promise\PromiseInterface
-     */
-    public static function join(array $promises)
-    {
-        if (empty($promises)) {
-            return static::resolve([]);
-        }
-        
-        return new static(function ($resolve, $reject) use ($promises) {
-            $pending = count($promises);
-            $values = [];
-            
-            foreach ($promises as $key => $promise) {
-                $onFulfilled = function ($value) use ($key, &$values, &$pending, $resolve) {
-                    $values[$key] = $value;
-                    if (0 === --$pending) {
-                        $resolve($values);
-                    }
-                };
-                
-                static::resolve($promise)->done($onFulfilled, $reject);
-            }
-        });
-    }
-    
-    /**
-     * Returns a promise that is fulfilled when any promise is fulfilled, and rejected only if all promises are rejected.
-     *
-     * @param   mixed[] $promises Promises or values (passed through resolve() to create promises).
-     *
-     * @return  \Icicle\Promise\PromiseInterface
-     */
-    public static function any(array $promises)
-    {
-        if (empty($promises)) {
-            return static::reject(new LogicException('No promises provided.'));
-        }
-        
-        return new static(function ($resolve, $reject) use ($promises) {
-            $pending = count($promises);
-            $exceptions = [];
-            
-            foreach ($promises as $key => $promise) {
-                $onRejected = function (Exception $exception) use ($key, &$exceptions, &$pending, $reject) {
-                    $exceptions[$key] = $exception;
-                    if (0 === --$pending) {
-                        $reject(new MultiReasonException($exceptions));
-                    }
-                };
-                
-                static::resolve($promise)->done($resolve, $onRejected);
-            }
-        });
-    }
-    
-    /**
-     * Returns a promise that is fulfilled when $required number of promises are fulfilled. The promise is rejected if
-     * $required number of promises can no longer be fulfilled.
-     *
-     * @param   mixed[] $promises Promises or values (passed through resolve() to create promises).
-     * @param   int $required Number of promises that must be fulfilled to fulfill the returned promise.
-     *
-     * @return  \Icicle\Promise\PromiseInterface
-     */
-    public static function some(array $promises, $required)
-    {
-        $required = (int) $required;
-        
-        if (0 >= $required) {
-            return static::resolve([]);
-        }
-        
-        if ($required > count($promises)) {
-            return static::reject(new LogicException('Too few promises provided.'));
-        }
-        
-        return new static(function ($resolve, $reject) use ($promises, $required) {
-            $pending = count($promises);
-            $required = min($pending, $required);
-            $values = [];
-            $exceptions = [];
-            
-            foreach ($promises as $key => $promise) {
-                $onFulfilled = function ($value) use ($key, &$values, &$pending, &$required, $resolve) {
-                    $values[$key] = $value;
-                    --$pending;
-                    if (0 === --$required) {
-                        $resolve($values);
-                    }
-                };
-                
-                $onRejected = function ($exception) use ($key, &$exceptions, &$pending, &$required, $reject) {
-                    $exceptions[$key] = $exception;
-                    if ($required > --$pending) {
-                        $reject(new MultiReasonException($exceptions));
-                    }
-                };
-                
-                static::resolve($promise)->done($onFulfilled, $onRejected);
-            }
-        });
-    }
-    
-    /**
-     * Returns a promise that is fulfilled or rejected when the first promise is fulfilled or rejected.
-     *
-     * @param   mixed[] $promises Promises or values (passed through resolve() to create promises).
-     *
-     * @return  \Icicle\Promise\PromiseInterface
-     */
-    public static function choose(array $promises)
-    {
-        if (empty($promises)) {
-            return static::reject(new LogicException('No promises provided.'));
-        }
-        
-        return new static(function ($resolve, $reject) use ($promises) {
-            foreach ($promises as $promise) {
-                static::resolve($promise)->done($resolve, $reject);
-            }
-        });
-    }
-    
-    /**
-     * Maps the callback to each promise as it is fulfilled. Returns an array of promises resolved by the return
-     * callback value of the callback function. The callback may return promises or throw exceptions to reject promises
-     * in the array. If a promise in the passed array rejects, the callback will not be called and the promise in the
-     * array is rejected for the same reason. Tip: Use join() or settle() method to determine when all promises in the
-     * array have been resolved.
-     *
-     * @param   mixed[] $promises Promises or values (passed through resolve() to create promises).
-     * @param   callable $callback (mixed $value) : mixed
-     *
-     * @return  \Icicle\Promise\PromiseInterface[] Array of promises resolved with the result of the mapped function.
-     */
-    public static function map(array $promises, callable $callback)
-    {
-        $results = [];
-        
-        foreach ($promises as $key => $promise) {
-            $results[$key] = static::resolve($promise)->then($callback);
-        }
-        
-        return $results;
-    }
-    
-    /**
-     * Reduce function similar to array_reduce(), only it works on promises and/or values. The callback function may
-     * return a promise or value and the initial value may also be a promise or value.
-     *
-     * @param   mixed[] $promises Promises or values (passed through resolve() to create promises).
-     * @param   callable $callback (mixed $carry, mixed $value) : mixed Called for each fulfilled promise value.
-     * @param   mixed $initial The initial value supplied for the $carry parameter of the callback function.
-     *
-     * @return  \Icicle\Promise\PromiseInterface
-     */
-    public static function reduce(array $promises, callable $callback, $initial = null)
-    {
-        if (empty($promises)) {
-            return static::resolve($initial);
-        }
-        
-        return $result = new static(function ($resolve, $reject) use (&$result, $promises, $callback, $initial) {
-            $pending = count($promises);
-            $carry = static::resolve($initial);
-            $carry->done(null, $reject);
-            
-            $onFulfilled = function ($value) use (&$carry, &$result, &$pending, $callback, $resolve, $reject) {
-                if ($result->isPending()) {
-                    $carry = $carry->then(function ($carry) use ($callback, $value) {
-                        return $callback($carry, $value);
-                    });
-                    $carry->done(null, $reject);
-
-                    if (0 === --$pending) {
-                        $resolve($carry);
-                    }
-                }
-            };
-            
-            foreach ($promises as $promise) {
-                static::resolve($promise)->done($onFulfilled, $reject);
-            }
-        });
-    }
-    
-    /**
-     * Calls $worker using the return value of the previous call until $predicate returns false. $seed is used as the
-     * initial parameter to $worker. $predicate is called before $worker with the value to be passed to $worker. If
-     * $worker or $predicate throws an exception, the promise is rejected using that exception. The call stack is
-     * cleared before each call to $worker to avoid filling the call stack. If $worker returns a promise, iteration
-     * waits for the returned promise to be resolved.
-     *
-     * @param   callable<mixed (mixed $value) $worker> Called with the previous return value on each iteration.
-     * @param   callable<bool (mixed $value) $predicate> Return false to stop iteration and fulfill promise.
-     * @param   mixed $seed Initial value given to $predicate and $worker (may be a promise).
-     *
-     * @return  \Icicle\Promise\PromiseInterface
-     */
-    public static function iterate(callable $worker, callable $predicate, $seed = null)
-    {
-        return $result = new static(
-            function ($resolve, $reject) use (&$result, &$promise, $worker, $predicate, $seed) {
-                $callback = function ($value) use (
-                    &$callback, &$result, &$promise, $worker, $predicate, $resolve, $reject
-                ) {
-                    if ($result->isPending()) {
-                        try {
-                            if (!$predicate($value)) { // Resolve promise if $predicate returns false.
-                                $resolve($value);
-                                return;
-                            }
-                            $promise = static::resolve($worker($value));
-                            $promise->done($callback, $reject);
-                        } catch (Exception $exception) {
-                            $reject($exception);
-                        }
-                    }
-                };
-
-                $promise = static::resolve($seed);
-                $promise->done($callback, $reject); // Start iteration with $seed.
-            },
-            function (Exception $exception) use (&$promise) {
-                $promise->cancel($exception);
-            }
-        );
-    }
-    
-    /**
-     * Repeatedly calls $promisor if the promise returned by $promisor is rejected or until $onRejected returns false.
-     * Useful to retry an operation a number of times or until an operation fails with a specific exception.
-     * If the promise returned by $promisor is fulfilled, the promise returned by this function is fulfilled with the
-     * same value.
-     *
-     * @param   callable<PromiseInterface ()> $promisor Performs an operation to be retried on failure.
-     *          Should return a promise, but can return any type of value (will be made into a promise using resolve()).
-     * @param   callable<bool (Exception $exception) $onRejected> This function is called if the promise returned by
-     *          $promisor is rejected. Returning true from this function will call $promiser again to retry the
-     *          operation.
-     *
-     * @return  \Icicle\Promise\PromiseInterface
-     */
-    public static function retry(callable $promisor, callable $onRejected)
-    {
-        return $result = new static(
-            function ($resolve, $reject) use (&$result, &$promise, $promisor, $onRejected) {
-                $callback = function (Exception $exception) use (
-                    &$callback, &$result, &$promise, $promisor, $onRejected, $resolve, $reject
-                ) {
-                    if ($result->isPending()) {
-                        try {
-                            if (!$onRejected($exception)) { // Reject promise if $onRejected returns false.
-                                $reject($exception);
-                                return;
-                            }
-                            $promise = static::resolve($promisor());
-                            $promise->done($resolve, $callback);
-                        } catch (Exception $exception) {
-                            $reject($exception);
-                        }
-                    }
-                };
-
-                $promise = static::resolve($promisor());
-                $promise->done($resolve, $callback);
-            },
-            function (Exception $exception) use (&$promise) {
-                $promise->cancel($exception);
-            }
-        );
     }
 }

--- a/src/Promise/PromiseInterface.php
+++ b/src/Promise/PromiseInterface.php
@@ -88,14 +88,14 @@ interface PromiseInterface
     public function cleanup(callable $onResolved);
 
     /**
-     * If the promises returns an array or a Traversable object, this function use the array (or array generated from
-     * traversing the iterator) as arguments to the given function. The array is key sorted before used as arguments.
-     * If the promise does not return an array, the returned promise will be rejected with an
-     * \Icicle\Promise\Exception\InvalidArgumentException.
+     * If the promise returns an array or a Traversable object, this function uses the array (or array generated from
+     * traversing the iterator) as arguments to the given function. The array is key sorted before being used as
+     * function arguments. If the promise does not return an array, the returned promise will be rejected with an
+     * \Icicle\Promise\Exception\TypeException.
      *
      * @param   callable $onFulfilled
      *
-     * @return  mixed
+     * @return  \Icicle\Promise\PromiseInterface
      */
     public function splat(callable $onFulfilled);
     

--- a/src/Promise/PromiseTrait.php
+++ b/src/Promise/PromiseTrait.php
@@ -48,7 +48,7 @@ trait PromiseTrait
      */
     public function tap(callable $onFulfilled) {
         return $this->then(function ($value) use ($onFulfilled) {
-            return Promise::resolve($onFulfilled($value))->then(function () {
+            return resolve($onFulfilled($value))->then(function () {
                 return $this;
             });
         });
@@ -60,7 +60,7 @@ trait PromiseTrait
     public function cleanup(callable $onResolved)
     {
         $onResolved = function () use ($onResolved) {
-            return Promise::resolve($onResolved())->then(function () {
+            return resolve($onResolved())->then(function () {
                 return $this;
             });
         };
@@ -76,9 +76,7 @@ trait PromiseTrait
         return $this->then(function ($values) use ($onFulfilled) {
             if ($values instanceof \Traversable) {
                 $values = iterator_to_array($values);
-            }
-
-            if (!is_array($values)) {
+            } elseif (!is_array($values)) {
                 throw new TypeException(sprintf(
                     'Expected array or Traversable for promise result, got %s',
                     is_object($values) ? get_class($values) : gettype($values)

--- a/src/Promise/Structures/FulfilledPromise.php
+++ b/src/Promise/Structures/FulfilledPromise.php
@@ -1,7 +1,7 @@
 <?php
 namespace Icicle\Promise\Structures;
 
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Promise\Exception\TypeException;
 use Icicle\Promise\Promise;
 use Icicle\Promise\PromiseInterface;
@@ -37,7 +37,7 @@ class FulfilledPromise extends ResolvedPromise
         }
         
         return new Promise(function ($resolve, $reject) use ($onFulfilled) {
-            Loop::schedule(function () use ($resolve, $reject, $onFulfilled) {
+            Loop\schedule(function () use ($resolve, $reject, $onFulfilled) {
                 try {
                     $resolve($onFulfilled($this->value));
                 } catch (\Exception $exception) {
@@ -53,7 +53,7 @@ class FulfilledPromise extends ResolvedPromise
     public function done(callable $onFulfilled = null, callable $onRejected = null)
     {
         if (null !== $onFulfilled) {
-            Loop::schedule($onFulfilled, $this->value);
+            Loop\schedule($onFulfilled, $this->value);
         }
     }
     
@@ -64,7 +64,7 @@ class FulfilledPromise extends ResolvedPromise
     {
         return new Promise(
             function ($resolve) use (&$timer, $time) {
-                $timer = Loop::timer($time, function () use ($resolve) {
+                $timer = Loop\timer($time, function () use ($resolve) {
                     $resolve($this);
                 });
             },

--- a/src/Promise/Structures/LazyPromise.php
+++ b/src/Promise/Structures/LazyPromise.php
@@ -1,5 +1,9 @@
 <?php
-namespace Icicle\Promise;
+namespace Icicle\Promise\Structures;
+
+use Icicle\Promise;
+use Icicle\Promise\PromiseInterface;
+use Icicle\Promise\PromiseTrait;
 
 class LazyPromise implements PromiseInterface
 {
@@ -24,7 +28,7 @@ class LazyPromise implements PromiseInterface
     }
     
     /**
-     * @return  PromiseInterface
+     * @return  \Icicle\Promise\PromiseInterface
      */
     protected function getPromise()
     {
@@ -33,9 +37,9 @@ class LazyPromise implements PromiseInterface
             $this->promisor = null;
             
             try {
-                $this->promise = Promise::resolve($promisor());
+                $this->promise = Promise\resolve($promisor());
             } catch (\Exception $exception) {
-                $this->promise = Promise::reject($exception);
+                $this->promise = Promise\reject($exception);
             }
         }
         
@@ -120,35 +124,5 @@ class LazyPromise implements PromiseInterface
     public function unwrap()
     {
         return $this->getPromise()->unwrap();
-    }
-    
-    /**
-     * @param   callable $promisor
-     * @param   mixed ...$args
-     *
-     * @return  LazyPromise
-     */
-    public static function call(callable $promisor /* , ...$args */)
-    {
-        $args = array_slice(func_get_args(), 1);
-        
-        return static::create($promisor, $args);
-    }
-    
-    /**
-     * @param   callable $promisor
-     * @param   mixed[] $args
-     *
-     * @return  LazyPromise
-     */
-    public static function create(callable $promisor, array $args = null)
-    {
-        return new static(function () use ($promisor, $args) {
-            if (empty($args)) {
-                return $promisor();
-            }
-            
-            return call_user_func_array($promisor, $args);
-        });
     }
 }

--- a/src/Promise/Structures/RejectedPromise.php
+++ b/src/Promise/Structures/RejectedPromise.php
@@ -2,7 +2,7 @@
 namespace Icicle\Promise\Structures;
 
 use Exception;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Promise\Exception\RejectedException;
 use Icicle\Promise\Promise;
 
@@ -35,7 +35,7 @@ class RejectedPromise extends ResolvedPromise
         }
         
         return new Promise(function ($resolve, $reject) use ($onRejected) {
-            Loop::schedule(function () use ($resolve, $reject, $onRejected) {
+            Loop\schedule(function () use ($resolve, $reject, $onRejected) {
                 try {
                     $resolve($onRejected($this->exception));
                 } catch (Exception $exception) {
@@ -51,9 +51,9 @@ class RejectedPromise extends ResolvedPromise
     public function done(callable $onFulfilled = null, callable $onRejected = null)
     {
         if (null !== $onRejected) {
-            Loop::schedule($onRejected, $this->exception);
+            Loop\schedule($onRejected, $this->exception);
         } else {
-            Loop::schedule(function () {
+            Loop\schedule(function () {
                 throw $this->exception; // Rethrow exception in uncatchable way.
             });
         }

--- a/src/Promise/functions.php
+++ b/src/Promise/functions.php
@@ -304,7 +304,7 @@ if (!function_exists(__NAMESPACE__ . '\resolve')) {
      * array is rejected for the same reason. Tip: Use join() or settle() method to determine when all promises in the
      * array have been resolved.
      *
-     * @param   callable<(mixed[] $promises): mixed> $callback
+     * @param   callable<mixed (mixed $value)> $callback
      * @param   mixed[] $promises Promises or values (passed through resolve() to create promises).
      *
      * @return  \Icicle\Promise\PromiseInterface[] Array of promises resolved with the result of the mapped function.

--- a/src/Promise/functions.php
+++ b/src/Promise/functions.php
@@ -1,0 +1,449 @@
+<?php
+namespace Icicle\Promise;
+
+use Exception;
+use Icicle\Promise\Exception\LogicException;
+use Icicle\Promise\Exception\MultiReasonException;
+use Icicle\Promise\Exception\TypeException;
+use Icicle\Promise\Structures\FulfilledPromise;
+use Icicle\Promise\Structures\LazyPromise;
+use Icicle\Promise\Structures\RejectedPromise;
+
+if (!function_exists(__NAMESPACE__ . '\resolve')) {
+    /**
+     * Return a promise using the given value. There are two possible outcomes depending on the type of the passed value:
+     * (1) PromiseInterface: The promise is returned without modification.
+     * (2) All other types: A fulfilled promise is returned using the given value as the result.
+     *
+     * @param   mixed $value
+     *
+     * @return  \Icicle\Promise\PromiseInterface
+     */
+    function resolve($value = null)
+    {
+        if ($value instanceof PromiseInterface) {
+            return $value;
+        }
+
+        return new FulfilledPromise($value);
+    }
+    
+    /**
+     * Create a new rejected promise using the given reason.
+     *
+     * @param   mixed $reason
+     *
+     * @return  \Icicle\Promise\PromiseInterface
+     */
+    function reject($reason = null)
+    {
+        return new RejectedPromise($reason);
+    }
+    
+    /**
+     * Wraps the given callable $worker in a promise aware function that takes the same number of arguments as $worker,
+     * but those arguments may be promises for the future argument value or just values. The returned function will
+     * return a promise for the return value of $worker and will never throw. The $worker function will not be called
+     * until each promise given as an argument is fulfilled. If any promise provided as an argument rejects, the promise
+     * returned by the returned function will be rejected for the same reason. The promise is fulfilled with the return
+     * value of $worker or rejected if $worker throws.
+     *
+     * @param   callable $worker
+     *
+     * @return  callable
+     */
+    function lift(callable $worker)
+    {
+        /**
+         * @param   mixed ...$args Promises or values.
+         *
+         * @return  \Icicle\Promise\PromiseInterface
+         */
+        return function (/* ...$args */) use ($worker) {
+            return join(func_get_args())->splat($worker);
+        };
+    }
+    
+    /**
+     * Transforms a function that takes a callback into a function that returns a promise. The promise is fulfilled with
+     * an array of the parameters that would have been passed to the callback function.
+     *
+     * @param   callable $worker Function that normally accepts a callback.
+     * @param   int $index Position of callback in $worker argument list (0-indexed).
+     *
+     * @return  callable
+     */
+    function promisify(callable $worker, $index = 0)
+    {
+        return function (/* ...$args */) use ($worker, $index) {
+            $args = func_get_args();
+
+            return new Promise(function ($resolve) use ($worker, $index, $args) {
+                $callback = function (/* ...$args */) use ($resolve) {
+                    $resolve(func_get_args());
+                };
+
+                if (count($args) < $index) {
+                    throw new LogicException('Too few arguments given to function.');
+                }
+
+                array_splice($args, $index, 0, [$callback]);
+
+                call_user_func_array($worker, $args);
+            });
+        };
+    }
+
+    /**
+     * Adapts any object with a then(callable $onFulfilled, callable $onRejected) method to a promise usable by
+     * components depending on promises implementing PromiseInterface.
+     *
+     * @param   object $thenable Object with a then() method.
+     *
+     * @return  PromiseInterface Promise resolved by the $thenable object.
+     */
+    function adapt($thenable)
+    {
+        if (!is_object($thenable) || !method_exists($thenable, 'then')) {
+            return reject(new TypeException('Must provide an object with a then() method.'));
+        }
+
+        return new Promise(function ($resolve, $reject) use ($thenable) {
+            $thenable->then($resolve, $reject);
+        });
+    }
+
+    /**
+     * Returns a promise that calls $promisor only when the result of the promise is requested (e.g., then() or done()
+     * is called on the returned promise. $pormisor can return a promise or any value. If $promisor throws an exception,
+     * the returned promise is rejected with that exception.
+     *
+     * @param   callable $promisor
+     * @param   mixed ...$args
+     *
+     * @return  \Icicle\Promise\PromiseInterface
+     */
+    function lazy(callable $promisor /* ...$args */)
+    {
+        $args = array_slice(func_get_args(), 1);
+
+        if (empty($args)) {
+            return new LazyPromise($promisor);
+        }
+
+        return new LazyPromise(function () use ($promisor, $args) {
+            return call_user_func_array($promisor, $args);
+        });
+    }
+
+    /**
+     * Returns a promise that is resolved when all promises are resolved. The returned promise will not reject by itself
+     * (only if cancelled). Returned promise is fulfilled with an array of resolved promises, with keys identical and
+     * corresponding to the original given array.
+     *
+     * @param   mixed[] $promises Promises or values (passed through resolve() to create promises).
+     *
+     * @return  \Icicle\Promise\PromiseInterface
+     */
+    function settle(array $promises)
+    {
+        if (empty($promises)) {
+            return resolve([]);
+        }
+
+        return new Promise(function ($resolve) use ($promises) {
+            $pending = count($promises);
+
+            $after = function () use (&$promises, &$pending, $resolve) {
+                if (0 === --$pending) {
+                    $resolve($promises);
+                }
+            };
+
+            foreach ($promises as &$promise) {
+                $promise = resolve($promise);
+                $promise->done($after, $after);
+            }
+        });
+    }
+    
+    /**
+     * Returns a promise that is fulfilled when all promises are fulfilled, and rejected if any promise is rejected.
+     * Returned promise is fulfilled with an array of values used to fulfill each contained promise, with keys
+     * corresponding to the array of promises.
+     *
+     * @param   mixed[] $promises Promises or values (passed through resolve() to create promises).
+     *
+     * @return  \Icicle\Promise\PromiseInterface
+     */
+    function join(array $promises)
+    {
+        if (empty($promises)) {
+            return resolve([]);
+        }
+
+        return new Promise(function ($resolve, $reject) use ($promises) {
+            $pending = count($promises);
+            $values = [];
+
+            foreach ($promises as $key => $promise) {
+                $onFulfilled = function ($value) use ($key, &$values, &$pending, $resolve) {
+                    $values[$key] = $value;
+                    if (0 === --$pending) {
+                        $resolve($values);
+                    }
+                };
+
+                resolve($promise)->done($onFulfilled, $reject);
+            }
+        });
+    }
+    
+    /**
+     * Returns a promise that is fulfilled when any promise is fulfilled, and rejected only if all promises are rejected.
+     *
+     * @param   mixed[] $promises Promises or values (passed through resolve() to create promises).
+     *
+     * @return  \Icicle\Promise\PromiseInterface
+     */
+    function any(array $promises)
+    {
+        if (empty($promises)) {
+            return reject(new LogicException('No promises provided.'));
+        }
+
+        return new Promise(function ($resolve, $reject) use ($promises) {
+            $pending = count($promises);
+            $exceptions = [];
+
+            foreach ($promises as $key => $promise) {
+                $onRejected = function (Exception $exception) use ($key, &$exceptions, &$pending, $reject) {
+                    $exceptions[$key] = $exception;
+                    if (0 === --$pending) {
+                        $reject(new MultiReasonException($exceptions));
+                    }
+                };
+
+                resolve($promise)->done($resolve, $onRejected);
+            }
+        });
+    }
+    
+    /**
+     * Returns a promise that is fulfilled when $required number of promises are fulfilled. The promise is rejected if
+     * $required number of promises can no longer be fulfilled.
+     *
+     * @param   mixed[] $promises Promises or values (passed through resolve() to create promises).
+     * @param   int $required Number of promises that must be fulfilled to fulfill the returned promise.
+     *
+     * @return  \Icicle\Promise\PromiseInterface
+     */
+    function some(array $promises, $required)
+    {
+        $required = (int) $required;
+
+        if (0 >= $required) {
+            return resolve([]);
+        }
+
+        if ($required > count($promises)) {
+            return reject(new LogicException('Too few promises provided.'));
+        }
+
+        return new Promise(function ($resolve, $reject) use ($promises, $required) {
+            $pending = count($promises);
+            $required = min($pending, $required);
+            $values = [];
+            $exceptions = [];
+
+            foreach ($promises as $key => $promise) {
+                $onFulfilled = function ($value) use ($key, &$values, &$pending, &$required, $resolve) {
+                    $values[$key] = $value;
+                    --$pending;
+                    if (0 === --$required) {
+                        $resolve($values);
+                    }
+                };
+
+                $onRejected = function ($exception) use ($key, &$exceptions, &$pending, &$required, $reject) {
+                    $exceptions[$key] = $exception;
+                    if ($required > --$pending) {
+                        $reject(new MultiReasonException($exceptions));
+                    }
+                };
+
+                resolve($promise)->done($onFulfilled, $onRejected);
+            }
+        });
+    }
+    
+    /**
+     * Returns a promise that is fulfilled or rejected when the first promise is fulfilled or rejected.
+     *
+     * @param   mixed[] $promises Promises or values (passed through resolve() to create promises).
+     *
+     * @return  \Icicle\Promise\PromiseInterface
+     */
+    function choose(array $promises)
+    {
+        if (empty($promises)) {
+            return reject(new LogicException('No promises provided.'));
+        }
+
+        return new Promise(function ($resolve, $reject) use ($promises) {
+            foreach ($promises as $promise) {
+                resolve($promise)->done($resolve, $reject);
+            }
+        });
+    }
+    
+    /**
+     * Maps the callback to each promise as it is fulfilled. Returns an array of promises resolved by the return
+     * callback value of the callback function. The callback may return promises or throw exceptions to reject promises
+     * in the array. If a promise in the passed array rejects, the callback will not be called and the promise in the
+     * array is rejected for the same reason. Tip: Use join() or settle() method to determine when all promises in the
+     * array have been resolved.
+     *
+     * @param   mixed[] $promises Promises or values (passed through resolve() to create promises).
+     * @param   callable $callback (mixed $value) : mixed
+     *
+     * @return  \Icicle\Promise\PromiseInterface[] Array of promises resolved with the result of the mapped function.
+     */
+    function map(array $promises, callable $callback)
+    {
+        $results = [];
+
+        foreach ($promises as $key => $promise) {
+            $results[$key] = resolve($promise)->then($callback);
+        }
+
+        return $results;
+    }
+    
+    /**
+     * Reduce function similar to array_reduce(), only it works on promises and/or values. The callback function may
+     * return a promise or value and the initial value may also be a promise or value.
+     *
+     * @param   mixed[] $promises Promises or values (passed through resolve() to create promises).
+     * @param   callable $callback (mixed $carry, mixed $value) : mixed Called for each fulfilled promise value.
+     * @param   mixed $initial The initial value supplied for the $carry parameter of the callback function.
+     *
+     * @return  \Icicle\Promise\PromiseInterface
+     */
+    function reduce(array $promises, callable $callback, $initial = null)
+    {
+        if (empty($promises)) {
+            return resolve($initial);
+        }
+
+        return $result = new Promise(function ($resolve, $reject) use (&$result, $promises, $callback, $initial) {
+            $pending = count($promises);
+            $carry = resolve($initial);
+            $carry->done(null, $reject);
+
+            $onFulfilled = function ($value) use (&$carry, &$result, &$pending, $callback, $resolve, $reject) {
+                if ($result->isPending()) {
+                    $carry = $carry->then(function ($carry) use ($callback, $value) {
+                        return $callback($carry, $value);
+                    });
+                    $carry->done(null, $reject);
+
+                    if (0 === --$pending) {
+                        $resolve($carry);
+                    }
+                }
+            };
+
+            foreach ($promises as $promise) {
+                resolve($promise)->done($onFulfilled, $reject);
+            }
+        });
+    }
+    
+    /**
+     * Calls $worker using the return value of the previous call until $predicate returns false. $seed is used as the
+     * initial parameter to $worker. $predicate is called before $worker with the value to be passed to $worker. If
+     * $worker or $predicate throws an exception, the promise is rejected using that exception. The call stack is
+     * cleared before each call to $worker to avoid filling the call stack. If $worker returns a promise, iteration
+     * waits for the returned promise to be resolved.
+     *
+     * @param   callable<mixed (mixed $value) $worker> Called with the previous return value on each iteration.
+     * @param   callable<bool (mixed $value) $predicate> Return false to stop iteration and fulfill promise.
+     * @param   mixed $seed Initial value given to $predicate and $worker (may be a promise).
+     *
+     * @return  \Icicle\Promise\PromiseInterface
+     */
+    function iterate(callable $worker, callable $predicate, $seed = null)
+    {
+        return $result = new Promise(
+            function ($resolve, $reject) use (&$result, &$promise, $worker, $predicate, $seed) {
+                $callback = function ($value) use (
+                    &$callback, &$result, &$promise, $worker, $predicate, $resolve, $reject
+                ) {
+                    if ($result->isPending()) {
+                        try {
+                            if (!$predicate($value)) { // Resolve promise if $predicate returns false.
+                                $resolve($value);
+                                return;
+                            }
+                            $promise = resolve($worker($value));
+                            $promise->done($callback, $reject);
+                        } catch (Exception $exception) {
+                            $reject($exception);
+                        }
+                    }
+                };
+
+                $promise = resolve($seed);
+                $promise->done($callback, $reject); // Start iteration with $seed.
+            },
+            function (Exception $exception) use (&$promise) {
+                $promise->cancel($exception);
+            }
+        );
+    }
+    
+    /**
+     * Repeatedly calls $promisor if the promise returned by $promisor is rejected or until $onRejected returns false.
+     * Useful to retry an operation a number of times or until an operation fails with a specific exception.
+     * If the promise returned by $promisor is fulfilled, the promise returned by this function is fulfilled with the
+     * same value.
+     *
+     * @param   callable<PromiseInterface ()> $promisor Performs an operation to be retried on failure.
+     *          Should return a promise, but can return any type of value (will be made into a promise using resolve()).
+     * @param   callable<bool (Exception $exception) $onRejected> This function is called if the promise returned by
+     *          $promisor is rejected. Returning true from this function will call $promiser again to retry the
+     *          operation.
+     *
+     * @return  \Icicle\Promise\PromiseInterface
+     */
+    function retry(callable $promisor, callable $onRejected)
+    {
+        return $result = new Promise(
+            function ($resolve, $reject) use (&$result, &$promise, $promisor, $onRejected) {
+                $callback = function (Exception $exception) use (
+                    &$callback, &$result, &$promise, $promisor, $onRejected, $resolve, $reject
+                ) {
+                    if ($result->isPending()) {
+                        try {
+                            if (!$onRejected($exception)) { // Reject promise if $onRejected returns false.
+                                $reject($exception);
+                                return;
+                            }
+                            $promise = resolve($promisor());
+                            $promise->done($resolve, $callback);
+                        } catch (Exception $exception) {
+                            $reject($exception);
+                        }
+                    }
+                };
+
+                $promise = resolve($promisor());
+                $promise->done($resolve, $callback);
+            },
+            function (Exception $exception) use (&$promise) {
+                $promise->cancel($exception);
+            }
+        );
+    }
+}

--- a/src/Promise/functions.php
+++ b/src/Promise/functions.php
@@ -115,8 +115,8 @@ if (!function_exists(__NAMESPACE__ . '\resolve')) {
 
     /**
      * Returns a promise that calls $promisor only when the result of the promise is requested (e.g., then() or done()
-     * is called on the returned promise. $pormisor can return a promise or any value. If $promisor throws an exception,
-     * the returned promise is rejected with that exception.
+     * is called on the returned promise). $promisor can return a promise or any value. If $promisor throws an
+     * exception, the returned promise is rejected with that exception.
      *
      * @param   callable $promisor
      * @param   mixed ...$args
@@ -304,20 +304,16 @@ if (!function_exists(__NAMESPACE__ . '\resolve')) {
      * array is rejected for the same reason. Tip: Use join() or settle() method to determine when all promises in the
      * array have been resolved.
      *
+     * @param   callable<(mixed[] $promises): mixed> $callback
      * @param   mixed[] $promises Promises or values (passed through resolve() to create promises).
-     * @param   callable $callback (mixed $value) : mixed
      *
      * @return  \Icicle\Promise\PromiseInterface[] Array of promises resolved with the result of the mapped function.
      */
-    function map(array $promises, callable $callback)
+    function map(callable $callback, array $promises)
     {
-        $results = [];
-
-        foreach ($promises as $key => $promise) {
-            $results[$key] = resolve($promise)->then($callback);
-        }
-
-        return $results;
+        return array_map(function ($promise) use ($callback) {
+            return resolve($promise)->then($callback);
+        }, $promises);
     }
     
     /**

--- a/src/Socket/Client/Connector.php
+++ b/src/Socket/Client/Connector.php
@@ -1,8 +1,8 @@
 <?php
 namespace Icicle\Socket\Client;
 
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Socket\Exception\InvalidArgumentException;
 use Icicle\Socket\Exception\FailureException;
 use Icicle\Socket\Exception\TimeoutException;
@@ -57,7 +57,7 @@ class Connector implements ConnectorInterface
         
         if (null !== $cafile) {
             if (!file_exists($cafile)) {
-                return Promise::reject(new InvalidArgumentException('No file exists at path given for cafile.'));
+                return Promise\reject(new InvalidArgumentException('No file exists at path given for cafile.'));
             }
             $context['ssl']['cafile'] = $cafile;
         }
@@ -76,13 +76,13 @@ class Connector implements ConnectorInterface
         );
         
         if (!$socket || $errno) {
-            return Promise::reject(new FailureException(
+            return Promise\reject(new FailureException(
                 sprintf('Could not connect to %s; Errno: %d; %s', $uri, $errno, $errstr)
             ));
         }
         
-        return new Promise(function ($resolve, $reject) use ($socket, $timeout) {
-            $await = Loop::await($socket, function ($resource, $expired) use (&$await, $resolve, $reject) {
+        return new Promise\Promise(function ($resolve, $reject) use ($socket, $timeout) {
+            $await = Loop\await($socket, function ($resource, $expired) use (&$await, $resolve, $reject) {
                 /** @var \Icicle\Loop\Events\SocketEventInterface $await */
                 $await->free();
                 

--- a/src/Socket/Server/Server.php
+++ b/src/Socket/Server/Server.php
@@ -2,9 +2,9 @@
 namespace Icicle\Socket\Server;
 
 use Exception;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Promise\Deferred;
-use Icicle\Promise\Promise;
 use Icicle\Socket\Client\Client;
 use Icicle\Socket\Exception\BusyException;
 use Icicle\Socket\Exception\ClosedException;
@@ -91,11 +91,11 @@ class Server extends Socket implements ServerInterface
     public function accept()
     {
         if (null !== $this->deferred) {
-            return Promise::reject(new BusyException('Already waiting on server.'));
+            return Promise\reject(new BusyException('Already waiting on server.'));
         }
         
         if (!$this->isOpen()) {
-            return Promise::reject(new UnavailableException('The server has been closed.'));
+            return Promise\reject(new UnavailableException('The server has been closed.'));
         }
 
         $this->poll->listen();
@@ -141,7 +141,7 @@ class Server extends Socket implements ServerInterface
      */
     private function createPoll($socket)
     {
-        return Loop::poll($socket, function ($resource) {
+        return Loop\poll($socket, function ($resource) {
             // Error reporting suppressed since stream_socket_accept() emits E_WARNING on client accept failure.
             $client = @stream_socket_accept($resource, 0); // Timeout of 0 to be non-blocking.
 

--- a/src/Socket/Stream/PipeTrait.php
+++ b/src/Socket/Stream/PipeTrait.php
@@ -1,7 +1,7 @@
 <?php
 namespace Icicle\Socket\Stream;
 
-use Icicle\Promise\Promise;
+use Icicle\Promise;
 use Icicle\Stream\Exception\UnwritableException;
 use Icicle\Stream\WritableStreamInterface;
 
@@ -67,17 +67,17 @@ trait PipeTrait
         $timeout = null
     ) {
         if (!$stream->isWritable()) {
-            return Promise::reject(new UnwritableException('The stream is not writable.'));
+            return Promise\reject(new UnwritableException('The stream is not writable.'));
         }
 
         $length = $this->parseLength($length);
         if (0 === $length) {
-            return Promise::resolve(0);
+            return Promise\resolve(0);
         }
 
         $byte = $this->parseByte($byte);
 
-        $promise = Promise::iterate(
+        $promise = Promise\iterate(
             function ($data) use (&$length, $stream, $byte, $timeout) {
                 static $bytes = 0;
                 $count = strlen($data);

--- a/src/Socket/Stream/ReadableStreamTrait.php
+++ b/src/Socket/Stream/ReadableStreamTrait.php
@@ -2,9 +2,9 @@
 namespace Icicle\Socket\Stream;
 
 use Exception;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Promise\Deferred;
-use Icicle\Promise\Promise;
 use Icicle\Socket\Exception\TimeoutException;
 use Icicle\Stream\Exception\BusyException;
 use Icicle\Socket\SocketInterface;
@@ -96,11 +96,11 @@ trait ReadableStreamTrait
     public function read($length = null, $byte = null, $timeout = null)
     {
         if (null !== $this->deferred) {
-            return Promise::reject(new BusyException('Already waiting on stream.'));
+            return Promise\reject(new BusyException('Already waiting on stream.'));
         }
         
         if (!$this->isReadable()) {
-            return Promise::reject(new UnreadableException('The stream is no longer readable.'));
+            return Promise\reject(new UnreadableException('The stream is no longer readable.'));
         }
 
         $this->length = $this->parseLength($length);
@@ -110,7 +110,7 @@ trait ReadableStreamTrait
         }
 
         if (0 === $this->length) {
-            return Promise::resolve('');
+            return Promise\resolve('');
         }
 
         $this->byte = $this->parseByte($byte);
@@ -119,12 +119,12 @@ trait ReadableStreamTrait
         $data = $this->fetch($resource);
 
         if ('' !== $data) {
-            return Promise::resolve($data);
+            return Promise\resolve($data);
         }
 
         if (feof($resource)) { // Close only if no data was read and at EOF.
             $this->close();
-            return Promise::resolve($data); // Resolve with empty string on EOF.
+            return Promise\resolve($data); // Resolve with empty string on EOF.
         }
 
         $this->poll->listen($timeout);
@@ -155,11 +155,11 @@ trait ReadableStreamTrait
     protected function poll($timeout = null)
     {
         if (null !== $this->deferred) {
-            return Promise::reject(new BusyException('Already waiting on stream.'));
+            return Promise\reject(new BusyException('Already waiting on stream.'));
         }
 
         if (!$this->isReadable()) {
-            return Promise::reject(new UnreadableException('The stream is no longer readable.'));
+            return Promise\reject(new UnreadableException('The stream is no longer readable.'));
         }
 
         $this->length = 0;
@@ -189,7 +189,7 @@ trait ReadableStreamTrait
      */
     private function createPoll($socket)
     {
-        return Loop::poll($socket, function ($resource, $expired) {
+        return Loop\poll($socket, function ($resource, $expired) {
             if ($expired) {
                 $this->deferred->reject(new TimeoutException('The connection timed out.'));
                 $this->deferred = null;

--- a/src/Socket/Stream/WritableStreamTrait.php
+++ b/src/Socket/Stream/WritableStreamTrait.php
@@ -2,9 +2,9 @@
 namespace Icicle\Socket\Stream;
 
 use Exception;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Promise\Deferred;
-use Icicle\Promise\Promise;
 use Icicle\Socket\Exception\FailureException;
 use Icicle\Socket\Exception\TimeoutException;
 use Icicle\Socket\SocketInterface;
@@ -98,7 +98,7 @@ trait WritableStreamTrait
     public function write($data, $timeout = null)
     {
         if (!$this->isWritable()) {
-            return Promise::reject(new UnwritableException('The stream is no longer writable.'));
+            return Promise\reject(new UnwritableException('The stream is no longer writable.'));
         }
         
         $data = new Buffer($data);
@@ -106,7 +106,7 @@ trait WritableStreamTrait
         
         if ($this->writeQueue->isEmpty()) {
             if ($data->isEmpty()) {
-                return Promise::resolve($written);
+                return Promise\resolve($written);
             }
             
             // Error reporting suppressed since fwrite() emits E_WARNING if the stream buffer is full.
@@ -119,11 +119,11 @@ trait WritableStreamTrait
                 }
                 $exception = new FailureException($message);
                 $this->free($exception);
-                return Promise::reject($exception);
+                return Promise\reject($exception);
             }
             
             if ($data->getLength() <= $written) {
-                return Promise::resolve($written);
+                return Promise\resolve($written);
             }
             
             $data->remove($written);
@@ -169,7 +169,7 @@ trait WritableStreamTrait
     protected function await($timeout = null)
     {
         if (!$this->isWritable()) {
-            return Promise::reject(new UnwritableException('The stream is no longer writable.'));
+            return Promise\reject(new UnwritableException('The stream is no longer writable.'));
         }
         
         $deferred = new Deferred();
@@ -197,7 +197,7 @@ trait WritableStreamTrait
      */
     private function createAwait($socket)
     {
-        return Loop::await($socket, function ($resource, $expired) {
+        return Loop\await($socket, function ($resource, $expired) {
             if ($expired) {
                 $this->free(new TimeoutException('Writing to the socket timed out.'));
                 return;

--- a/src/Stream/PipeTrait.php
+++ b/src/Stream/PipeTrait.php
@@ -1,7 +1,7 @@
 <?php
 namespace Icicle\Stream;
 
-use Icicle\Promise\Promise;
+use Icicle\Promise;
 use Icicle\Stream\Exception\UnwritableException;
 
 trait PipeTrait
@@ -59,17 +59,17 @@ trait PipeTrait
     public function pipe(WritableStreamInterface $stream, $endWhenUnreadable = true, $length = null, $byte = null)
     {
         if (!$stream->isWritable()) {
-            return Promise::reject(new UnwritableException('The stream is not writable.'));
+            return Promise\reject(new UnwritableException('The stream is not writable.'));
         }
 
         $length = $this->parseLength($length);
         if (0 === $length) {
-            return Promise::resolve(0);
+            return Promise\resolve(0);
         }
 
         $byte = $this->parseByte($byte);
 
-        $promise = Promise::iterate(
+        $promise = Promise\iterate(
             function ($data) use (&$length, $stream, $byte) {
                 static $bytes = 0;
                 $count = strlen($data);

--- a/src/Stream/Sink.php
+++ b/src/Stream/Sink.php
@@ -1,7 +1,7 @@
 <?php
 namespace Icicle\Stream;
 
-use Icicle\Promise\Promise;
+use Icicle\Promise;
 use Icicle\Stream\Exception\InvalidArgumentException;
 use Icicle\Stream\Exception\OutOfBoundsException;
 use Icicle\Stream\Exception\UnreadableException;
@@ -80,14 +80,14 @@ class Sink implements DuplexStreamInterface, SeekableStreamInterface
     public function read($length = null, $byte = null)
     {
         if (!$this->isReadable()) {
-            return Promise::reject(new UnreadableException('The stream is no longer readable.'));
+            return Promise\reject(new UnreadableException('The stream is no longer readable.'));
         }
 
         $length = $this->parseLength($length);
         $byte = $this->parseByte($byte);
 
         if (0 === $length) {
-            return Promise::resolve('');
+            return Promise\resolve('');
         }
 
         if (null !== $byte) {
@@ -99,7 +99,7 @@ class Sink implements DuplexStreamInterface, SeekableStreamInterface
                 $data .= $char;
             } while ($char !== $byte && (null === $length || ++$i < $length) && $this->iterator->valid());
 
-            return Promise::resolve($data);
+            return Promise\resolve($data);
         }
 
         if (null === $length) {
@@ -116,7 +116,7 @@ class Sink implements DuplexStreamInterface, SeekableStreamInterface
 
         $this->iterator->seek($position);
 
-        return Promise::resolve($data);
+        return Promise\resolve($data);
     }
 
     /**
@@ -152,7 +152,7 @@ class Sink implements DuplexStreamInterface, SeekableStreamInterface
     protected function send($data, $end = false)
     {
         if (!$this->isWritable()) {
-            return Promise::reject(new UnwritableException('The stream is no longer writable.'));
+            return Promise\reject(new UnwritableException('The stream is no longer writable.'));
         }
 
         if ($end) {
@@ -169,7 +169,7 @@ class Sink implements DuplexStreamInterface, SeekableStreamInterface
 
         $this->iterator->seek($this->iterator->key() + $length);
 
-        return Promise::resolve($length);
+        return Promise\resolve($length);
     }
 
     /**
@@ -178,7 +178,7 @@ class Sink implements DuplexStreamInterface, SeekableStreamInterface
     public function seek($offset, $whence = SEEK_SET)
     {
         if (!$this->isOpen()) {
-            return Promise::reject(new UnseekableException('The stream is no longer seekable.'));
+            return Promise\reject(new UnseekableException('The stream is no longer seekable.'));
         }
 
         $offset = (int) $offset;
@@ -196,18 +196,18 @@ class Sink implements DuplexStreamInterface, SeekableStreamInterface
                 break;
 
             default:
-                return Promise::reject(
+                return Promise\reject(
                     new InvalidArgumentException('Invalid value for whence. Use SEEK_SET, SEEK_CUR, or SEEK_END.')
                 );
         }
 
         if (0 > $offset || $this->buffer->getLength() <= $offset) {
-            return Promise::reject(new OutOfBoundsException(sprintf('Invalid offset: %s.', $offset)));
+            return Promise\reject(new OutOfBoundsException(sprintf('Invalid offset: %s.', $offset)));
         }
 
         $this->iterator->seek($offset);
 
-        return Promise::resolve($offset);
+        return Promise\resolve($offset);
     }
 
     /**

--- a/src/Stream/Stream.php
+++ b/src/Stream/Stream.php
@@ -2,8 +2,8 @@
 namespace Icicle\Stream;
 
 use Exception;
+use Icicle\Promise;
 use Icicle\Promise\Deferred;
-use Icicle\Promise\Promise;
 use Icicle\Stream\Exception\BusyException;
 use Icicle\Stream\Exception\ClosedException;
 use Icicle\Stream\Exception\UnreadableException;
@@ -130,11 +130,11 @@ class Stream implements DuplexStreamInterface
     public function read($length = null, $byte = null)
     {
         if (null !== $this->deferred) {
-            return Promise::reject(new BusyException('Already waiting on stream.'));
+            return Promise\reject(new BusyException('Already waiting on stream.'));
         }
 
         if (!$this->isReadable()) {
-            return Promise::reject(new UnreadableException('The stream is no longer readable.'));
+            return Promise\reject(new UnreadableException('The stream is no longer readable.'));
         }
 
         $this->length = $this->parseLength($length);
@@ -155,7 +155,7 @@ class Stream implements DuplexStreamInterface
                 $this->free();
             }
 
-            return Promise::resolve($data);
+            return Promise\resolve($data);
         }
 
         $this->deferred = new Deferred(function () {
@@ -222,7 +222,7 @@ class Stream implements DuplexStreamInterface
     protected function send($data, $end = false)
     {
         if (!$this->isWritable()) {
-            return Promise::reject(new UnwritableException('The stream is no longer writable.'));
+            return Promise\reject(new UnwritableException('The stream is no longer writable.'));
         }
 
         $this->buffer->push($data);
@@ -246,7 +246,7 @@ class Stream implements DuplexStreamInterface
             return $deferred->getPromise();
         }
 
-        return Promise::resolve(strlen($data));
+        return Promise\resolve(strlen($data));
     }
 
     /**

--- a/tests/Coroutine/CoroutineTest.php
+++ b/tests/Coroutine/CoroutineTest.php
@@ -4,20 +4,17 @@ namespace Icicle\Tests\Coroutine;
 use Exception;
 use Icicle\Coroutine\Coroutine;
 use Icicle\Coroutine\Exception\InvalidCallableException;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Tests\TestCase;
 
-/**
- * @requires PHP 5.5
- */
 class CoroutineTest extends TestCase
 {
     const TIMEOUT = 0.1;
     
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
     
     public function testYieldScalar()
@@ -36,7 +33,7 @@ class CoroutineTest extends TestCase
         
         $coroutine->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame($value, $yielded);
         $this->assertTrue($coroutine->isFulfilled());
@@ -48,7 +45,7 @@ class CoroutineTest extends TestCase
         $value = 1;
         
         $generator = function () use (&$yielded, $value) {
-            $yielded = (yield Promise::resolve($value));
+            $yielded = (yield Promise\resolve($value));
         };
         
         $coroutine = new Coroutine($generator());
@@ -59,7 +56,7 @@ class CoroutineTest extends TestCase
         
         $coroutine->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame($value, $yielded);
         $this->assertTrue($coroutine->isFulfilled());
@@ -71,7 +68,7 @@ class CoroutineTest extends TestCase
         $exception = new Exception();
         
         $generator = function () use (&$yielded, $exception) {
-            $yielded = (yield Promise::reject($exception));
+            $yielded = (yield Promise\reject($exception));
         };
         
         $coroutine = new Coroutine($generator());
@@ -82,7 +79,7 @@ class CoroutineTest extends TestCase
         
         $coroutine->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertNull($yielded);
         $this->assertTrue($coroutine->isRejected());
@@ -97,7 +94,7 @@ class CoroutineTest extends TestCase
         $value = 1;
 
         $generator = function () use (&$yielded, $value) {
-            $yielded = (yield Promise::resolve($value)->delay(self::TIMEOUT));
+            $yielded = (yield Promise\resolve($value)->delay(self::TIMEOUT));
         };
         
         $coroutine = new Coroutine($generator());
@@ -108,7 +105,7 @@ class CoroutineTest extends TestCase
         
         $coroutine->done($callback, $this->createCallback(0));
         
-        $this->assertRunTimeGreaterThan(['Icicle\Loop\Loop', 'run'], self::TIMEOUT);
+        $this->assertRunTimeGreaterThan('Icicle\Loop\run', self::TIMEOUT);
         
         $this->assertSame($value, $yielded);
         $this->assertTrue($coroutine->isFulfilled());
@@ -136,7 +133,7 @@ class CoroutineTest extends TestCase
         
         $this->assertInstanceOf('Icicle\Promise\PromiseInterface', $child);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($child->isFulfilled());
     }
@@ -152,7 +149,7 @@ class CoroutineTest extends TestCase
         
         $generator = function () use ($value, $exception) {
             try {
-                yield Promise::reject($exception);
+                yield Promise\reject($exception);
             } catch (Exception $exception) {
                 yield $value;
             }
@@ -166,7 +163,7 @@ class CoroutineTest extends TestCase
         
         $coroutine->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($coroutine->isFulfilled());
         $this->assertSame($value, $coroutine->getResult());
@@ -189,7 +186,7 @@ class CoroutineTest extends TestCase
         
         $coroutine->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($coroutine->isRejected());
         $this->assertSame($exception, $coroutine->getResult());
@@ -220,7 +217,7 @@ class CoroutineTest extends TestCase
 
         $child = $coroutine->then($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($coroutine->isFulfilled());
         $this->assertSame($value, $coroutine->getResult());
@@ -252,7 +249,7 @@ class CoroutineTest extends TestCase
 
         $coroutine->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($coroutine->isRejected());
         $this->assertSame($exception, $coroutine->getResult());
@@ -270,7 +267,7 @@ class CoroutineTest extends TestCase
 
         $generator = function () use ($exception, $callback) {
             try {
-                yield Promise::reject($exception);
+                yield Promise\reject($exception);
             } finally {
                 $callback();
             }
@@ -284,7 +281,7 @@ class CoroutineTest extends TestCase
 
         $coroutine->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($coroutine->isRejected());
         $this->assertSame($exception, $coroutine->getResult());
@@ -302,7 +299,7 @@ class CoroutineTest extends TestCase
 
         $generator = function () use (&$yielded, $exception, $callback, $value) {
             try {
-                $yielded = (yield Promise::resolve($value)->delay(self::TIMEOUT));
+                $yielded = (yield Promise\resolve($value)->delay(self::TIMEOUT));
                 throw $exception;
             } finally {
                 $callback();
@@ -317,7 +314,7 @@ class CoroutineTest extends TestCase
 
         $coroutine->done($this->createCallback(0), $callback);
 
-        $this->assertRunTimeGreaterThan(['Icicle\Loop\Loop', 'run'], self::TIMEOUT);
+        $this->assertRunTimeGreaterThan('Icicle\Loop\run', self::TIMEOUT);
 
         $this->assertSame($value, $yielded);
         $this->assertTrue($coroutine->isRejected());
@@ -337,7 +334,7 @@ class CoroutineTest extends TestCase
             try {
                 throw $exception;
             } finally {
-                $yielded = (yield Promise::resolve($value)->delay(self::TIMEOUT));
+                $yielded = (yield Promise\resolve($value)->delay(self::TIMEOUT));
             }
         };
 
@@ -349,7 +346,7 @@ class CoroutineTest extends TestCase
 
         $coroutine->done($this->createCallback(0), $callback);
 
-        $this->assertRunTimeGreaterThan(['Icicle\Loop\Loop', 'run'], self::TIMEOUT);
+        $this->assertRunTimeGreaterThan('Icicle\Loop\run', self::TIMEOUT);
 
         $this->assertSame($value, $yielded);
         $this->assertTrue($coroutine->isRejected());
@@ -379,7 +376,7 @@ class CoroutineTest extends TestCase
         
         $coroutine->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame($value, $yielded);
         $this->assertTrue($coroutine->isFulfilled());
@@ -406,7 +403,7 @@ class CoroutineTest extends TestCase
         
         $coroutine->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($coroutine->isRejected());
     }
@@ -434,7 +431,7 @@ class CoroutineTest extends TestCase
         
         $coroutine->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -462,7 +459,7 @@ class CoroutineTest extends TestCase
         
         $coroutine->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($coroutine->isRejected());
         $this->assertSame($exception, $coroutine->getResult());
@@ -493,7 +490,7 @@ class CoroutineTest extends TestCase
         
         $coroutine->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($coroutine->isRejected());
         $this->assertSame($exception, $coroutine->getResult());
@@ -507,12 +504,12 @@ class CoroutineTest extends TestCase
         $exception = new Exception();
         
         $generator = function () use (&$promise) {
-            yield ($promise = Promise::resolve(1)->delay(0.1));
+            yield ($promise = Promise\resolve(1)->delay(0.1));
         };
         
         $coroutine = new Coroutine($generator());
         
-        Loop::tick(); // Get to first yield statement.
+        Loop\tick(); // Get to first yield statement.
         
         $this->assertTrue($coroutine->isPending());
         $this->assertInstanceOf('Icicle\Promise\Promise', $promise);
@@ -525,7 +522,7 @@ class CoroutineTest extends TestCase
         
         $coroutine->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($promise->isRejected());
         $this->assertSame($exception, $promise->getResult());
@@ -540,15 +537,15 @@ class CoroutineTest extends TestCase
         
         $generator = function () use (&$promise) {
             try {
-                yield Promise::resolve(1)->delay(0.1);
+                yield Promise\resolve(1)->delay(0.1);
             } catch (Exception $exception) {
-                yield ($promise = Promise::resolve(2)->delay(0.1));
+                yield ($promise = Promise\resolve(2)->delay(0.1));
             }
         };
         
         $coroutine = new Coroutine($generator());
         
-        Loop::tick(); // Get to first yield statement.
+        Loop\tick(); // Get to first yield statement.
         
         $coroutine->cancel($exception);
         
@@ -558,7 +555,7 @@ class CoroutineTest extends TestCase
         
         $coroutine->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertInstanceOf('Icicle\Promise\Promise', $promise);
         $this->assertTrue($promise->isRejected());
@@ -571,7 +568,7 @@ class CoroutineTest extends TestCase
     public function testTimeout()
     {
         $generator = function () use (&$promise) {
-            yield ($promise = new Promise(function () {
+            yield ($promise = new Promise\Promise(function () {
             })); // Yield promise that will never resolve.
         };
         
@@ -587,7 +584,7 @@ class CoroutineTest extends TestCase
         
         $timeout->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($coroutine->isRejected());
         $this->assertTrue($timeout->isRejected());
@@ -614,7 +611,7 @@ class CoroutineTest extends TestCase
         
         $delayed->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($delayed->isFulfilled());
         $this->assertSame($value, $delayed->getResult());
@@ -638,7 +635,7 @@ class CoroutineTest extends TestCase
         
         $this->expectOutputString('[1][2][3][1][2][3][1][2][1][2][1][2][1][1][1]');
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -662,7 +659,7 @@ class CoroutineTest extends TestCase
         
         $coroutine->done($this->createCallback(0), $this->createCallback(1));
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($coroutine->isRejected());
         $this->assertInstanceOf('Icicle\Coroutine\Exception\InvalidGeneratorException', $coroutine->getResult());
@@ -674,7 +671,7 @@ class CoroutineTest extends TestCase
      */
     public function testAsync()
     {
-        $async = Coroutine::async(function ($left, $right) {
+        $async = \Icicle\Coroutine\async(function ($left, $right) {
             yield $left - $right;
         });
         
@@ -699,7 +696,7 @@ class CoroutineTest extends TestCase
         
         $coroutine2->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($coroutine1->isFulfilled());
         $this->assertSame(-1, $coroutine1->getResult());
@@ -716,7 +713,7 @@ class CoroutineTest extends TestCase
         $callback = function () {
         };
         
-        $async = Coroutine::async($callback);
+        $async = \Icicle\Coroutine\async($callback);
         
         try {
             $coroutine = $async();
@@ -735,7 +732,7 @@ class CoroutineTest extends TestCase
             throw new Exception();
         };
         
-        $async = Coroutine::async($callback);
+        $async = \Icicle\Coroutine\async($callback);
         
         try {
             $coroutine = $async();
@@ -748,9 +745,9 @@ class CoroutineTest extends TestCase
     /**
      * @depends testYieldScalar
      */
-    public function testCall()
+    public function testCreate()
     {
-        $coroutine = Coroutine::call(function ($left, $right) {
+        $coroutine = \Icicle\Coroutine\create(function ($left, $right) {
             yield $left - $right;
         }, 1, 2);
         
@@ -760,22 +757,22 @@ class CoroutineTest extends TestCase
         
         $coroutine->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($coroutine->isFulfilled());
         $this->assertSame(-1, $coroutine->getResult());
     }
     
     /**
-     * @depends testCall
+     * @depends testCreate
      */
-    public function testCallWithNonGeneratorCallable()
+    public function testCreateWithNonGeneratorCallable()
     {
         $callback = function () {
         };
         
         try {
-            $coroutine = Coroutine::call($callback);
+            $coroutine = \Icicle\Coroutine\create($callback);
             $this->fail('Expected exception of type Icicle\Coroutine\Exception\InvalidCallableException');
         } catch (InvalidCallableException $exception) {
             $this->assertSame($callback, $exception->getCallable());
@@ -783,16 +780,16 @@ class CoroutineTest extends TestCase
     }
     
     /**
-     * @depends testCall
+     * @depends testCreate
      */
-    public function testCallWithCallableThrowningException()
+    public function testCreateWithCallableThrowningException()
     {
         $callback = function () {
             throw new Exception();
         };
         
         try {
-            $coroutine = Coroutine::call($callback);
+            $coroutine = \Icicle\Coroutine\create($callback);
             $this->fail('Expected exception of type Icicle\Coroutine\Exception\InvalidCallableException');
         } catch (InvalidCallableException $exception) {
             $this->assertSame($callback, $exception->getCallable());
@@ -804,9 +801,9 @@ class CoroutineTest extends TestCase
      */
     public function testSleep()
     {
-        $coroutine = new Coroutine(Coroutine::sleep(self::TIMEOUT));
+        $coroutine = new Coroutine(\Icicle\Coroutine\sleep(self::TIMEOUT));
         
-        Loop::run();
+        Loop\run();
         
         $this->assertGreaterThanOrEqual(self::TIMEOUT, $coroutine->getResult());
     }
@@ -817,14 +814,14 @@ class CoroutineTest extends TestCase
     public function testPause()
     {
         $generator = function () {
-            yield Coroutine::sleep(self::TIMEOUT);
+            yield \Icicle\Coroutine\sleep(self::TIMEOUT);
         };
         
         $coroutine = new Coroutine($generator());
         
         $coroutine->pause();
         
-        $this->assertRunTimeLessThan(['Icicle\Loop\Loop', 'run'], self::TIMEOUT);
+        $this->assertRunTimeLessThan('Icicle\Loop\run', self::TIMEOUT);
     }
     
     /**
@@ -833,26 +830,26 @@ class CoroutineTest extends TestCase
     public function testResume()
     {
         $generator = function () use (&$coroutine) {
-            yield Coroutine::sleep(self::TIMEOUT);
+            yield \Icicle\Coroutine\sleep(self::TIMEOUT);
             
             $coroutine->pause();
             
             yield $coroutine->isPaused();
             
-            yield Coroutine::sleep(self::TIMEOUT);
+            yield \Icicle\Coroutine\sleep(self::TIMEOUT);
         };
         
         $coroutine = new Coroutine($generator());
         
-        $this->assertRunTimeBetween(['Icicle\Loop\Loop', 'run'], self::TIMEOUT, self::TIMEOUT * 2);
+        $this->assertRunTimeBetween('Icicle\Loop\run', self::TIMEOUT, self::TIMEOUT * 2);
         
         $coroutine->resume();
         
-        Loop::run();
+        Loop\run();
         
         $coroutine->resume();
         
-        Loop::run();
+        Loop\run();
         
         $this->assertFalse($coroutine->isPending());
         $this->assertGreaterThanOrEqual(self::TIMEOUT, $coroutine->getResult());
@@ -864,17 +861,17 @@ class CoroutineTest extends TestCase
     public function testResumeImmediatelyAfterPause()
     {
         $generator = function () use (&$coroutine) {
-            yield Coroutine::sleep(self::TIMEOUT);
+            yield \Icicle\Coroutine\sleep(self::TIMEOUT);
             
             $coroutine->pause();
             $coroutine->resume();
             
-            yield Coroutine::sleep(self::TIMEOUT);
+            yield \Icicle\Coroutine\sleep(self::TIMEOUT);
         };
         
         $coroutine = new Coroutine($generator());
         
-        $this->assertRunTimeGreaterThan(['Icicle\Loop\Loop', 'run'], self::TIMEOUT * 2);
+        $this->assertRunTimeGreaterThan('Icicle\Loop\run', self::TIMEOUT * 2);
     }
     
     /**
@@ -883,18 +880,18 @@ class CoroutineTest extends TestCase
     public function testResumeOnPendingPromise()
     {
         $generator = function () use (&$coroutine) {
-            yield Coroutine::sleep(self::TIMEOUT);
+            yield \Icicle\Coroutine\sleep(self::TIMEOUT);
             
             $coroutine->pause();
             
-            Loop::schedule([$coroutine, 'resume']);
+            Loop\schedule([$coroutine, 'resume']);
             
-            yield Coroutine::sleep(self::TIMEOUT);
+            yield \Icicle\Coroutine\sleep(self::TIMEOUT);
         };
         
         $coroutine = new Coroutine($generator());
         
-        Loop::run();
+        Loop\run();
         
         $this->assertFalse($coroutine->isPending());
         $this->assertGreaterThanOrEqual(self::TIMEOUT, $coroutine->getResult());
@@ -906,22 +903,22 @@ class CoroutineTest extends TestCase
     public function testResumeOnFulfilledPromise()
     {
         $generator = function () use (&$coroutine) {
-            yield Coroutine::sleep(self::TIMEOUT);
+            yield \Icicle\Coroutine\sleep(self::TIMEOUT);
             
             $coroutine->pause();
             
-            yield Promise::resolve(1);
+            yield Promise\resolve(1);
         };
         
         $coroutine = new Coroutine($generator());
         
-        Loop::run();
+        Loop\run();
         
         $coroutine->resume();
         
         $this->assertTrue($coroutine->isPending());
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($coroutine->isFulfilled());
         $this->assertSame(1, $coroutine->getResult());
@@ -935,22 +932,22 @@ class CoroutineTest extends TestCase
         $exception = new Exception();
         
         $generator = function () use (&$coroutine, &$exception) {
-            yield Coroutine::sleep(self::TIMEOUT);
+            yield \Icicle\Coroutine\sleep(self::TIMEOUT);
             
             $coroutine->pause();
             
-            yield $promise = Promise::reject($exception);
+            yield $promise = Promise\reject($exception);
         };
         
         $coroutine = new Coroutine($generator());
         
-        Loop::run();
+        Loop\run();
         
         $coroutine->resume();
         
         $this->assertTrue($coroutine->isPending());
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($coroutine->isRejected());
         $this->assertSame($exception, $coroutine->getResult());
@@ -964,36 +961,36 @@ class CoroutineTest extends TestCase
         $generator = function () use (&$coroutine) {
             $coroutine->pause();
 
-            yield Coroutine::sleep(self::TIMEOUT);
+            yield \Icicle\Coroutine\sleep(self::TIMEOUT);
 
             $coroutine->pause();
 
-            yield Coroutine::sleep(self::TIMEOUT);
+            yield \Icicle\Coroutine\sleep(self::TIMEOUT);
 
             $coroutine->pause();
 
-            yield Coroutine::sleep(self::TIMEOUT);
+            yield \Icicle\Coroutine\sleep(self::TIMEOUT);
 
             $coroutine->pause();
 
-            yield Coroutine::sleep(self::TIMEOUT);
+            yield \Icicle\Coroutine\sleep(self::TIMEOUT);
 
             throw new Exception('Coroutine should not reach this point.');
         };
 
         $coroutine = new Coroutine($generator());
 
-        Loop::run();
+        Loop\run();
 
         $coroutine->resume();
 
-        Loop::run();
+        Loop\run();
 
         $coroutine->resume();
 
-        Loop::run();
+        Loop\run();
 
-        Loop::run();
+        Loop\run();
 
         $coroutine->resume();
 
@@ -1010,7 +1007,7 @@ class CoroutineTest extends TestCase
             yield 'test';
         };
         
-        $promise = new Promise(function ($resolve) use ($generator) {
+        $promise = new Promise\Promise(function ($resolve) use ($generator) {
             $resolve(new Coroutine($generator()));
         });
         
@@ -1020,6 +1017,6 @@ class CoroutineTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Promise/DeferredTest.php
+++ b/tests/Promise/DeferredTest.php
@@ -2,18 +2,16 @@
 namespace Icicle\Tests\Promise;
 
 use Exception;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Promise\Deferred;
 use Icicle\Tests\TestCase;
 
-/**
- * @requires PHP 5.4
- */
 class DeferredTest extends TestCase
 {
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
     
     public function testResolve()
@@ -30,7 +28,7 @@ class DeferredTest extends TestCase
         
         $deferred->resolve($value);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($deferred->getPromise()->isFulfilled());
     }
@@ -49,7 +47,7 @@ class DeferredTest extends TestCase
         
         $deferred->reject($exception);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($deferred->getPromise()->isRejected());
     }
@@ -71,7 +69,7 @@ class DeferredTest extends TestCase
         
         $deferred->reject($reason);
         
-        Loop::run();
+        Loop\run();
         
         $promise = $deferred->getPromise();
         
@@ -97,7 +95,7 @@ class DeferredTest extends TestCase
         
         $deferred->getPromise()->cancel($exception);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($deferred->getPromise()->isRejected());
         $this->assertSame($exception, $deferred->getPromise()->getResult());

--- a/tests/Promise/PromiseAdaptTest.php
+++ b/tests/Promise/PromiseAdaptTest.php
@@ -1,19 +1,15 @@
 <?php
 namespace Icicle\Tests\Promise;
 
-use Exception;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Tests\TestCase;
 
-/**
- * @requires PHP 5.4
- */
 class PromiseAdaptTest extends TestCase
 {
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
     
     public function testThenCalled()
@@ -31,13 +27,13 @@ class PromiseAdaptTest extends TestCase
                 })
             );
 
-        $promise = Promise::adapt($mock);
+        $promise = Promise\adapt($mock);
 
         $this->assertInstanceOf('Icicle\Promise\PromiseInterface', $promise);
 
         $promise->done($this->createCallback(0), $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -55,7 +51,7 @@ class PromiseAdaptTest extends TestCase
                 $resolve($value);
             }));
 
-        $promise = Promise::adapt($mock);
+        $promise = Promise\adapt($mock);
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -63,7 +59,7 @@ class PromiseAdaptTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -81,7 +77,7 @@ class PromiseAdaptTest extends TestCase
                 $reject($reason);
             }));
 
-        $promise = Promise::adapt($mock);
+        $promise = Promise\adapt($mock);
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -89,14 +85,14 @@ class PromiseAdaptTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     public function testScalarValue()
     {
         $value = 1;
 
-        $promise = Promise::adapt($value);
+        $promise = Promise\adapt($value);
 
         $this->assertInstanceOf('Icicle\Promise\PromiseInterface', $promise);
 
@@ -106,14 +102,14 @@ class PromiseAdaptTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     public function testNonThenableObject()
     {
         $object = new \stdClass();
 
-        $promise = Promise::adapt($object);
+        $promise = Promise\adapt($object);
 
         $this->assertInstanceOf('Icicle\Promise\PromiseInterface', $promise);
 
@@ -123,6 +119,6 @@ class PromiseAdaptTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Promise/PromiseAnyTest.php
+++ b/tests/Promise/PromiseAnyTest.php
@@ -2,18 +2,15 @@
 namespace Icicle\Tests\Promise;
 
 use Exception;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Tests\TestCase;
 
-/**
- * @requires PHP 5.4
- */
 class PromiseAnyTest extends TestCase
 {
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
     
     public function testEmptyArray()
@@ -22,9 +19,9 @@ class PromiseAnyTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->isInstanceOf('Icicle\Promise\Exception\LogicException'));
         
-        Promise::any([])->done($this->createCallback(0), $callback);
+        Promise\any([])->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testValuesArray()
@@ -35,60 +32,60 @@ class PromiseAnyTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->identicalTo(1));
         
-        Promise::any($values)->done($callback, $this->createCallback(0));
+        Promise\any($values)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testPromisesArray()
     {
         $values = [1, 2, 3];
-        $promises = [Promise::resolve(1), Promise::resolve(2), Promise::resolve(3)];
+        $promises = [Promise\resolve(1), Promise\resolve(2), Promise\resolve(3)];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo(1));
         
-        Promise::any($promises)->done($callback, $this->createCallback(0));
+        Promise\any($promises)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testFulfillOnFirstInputPromiseFulfilled()
     {
         $exception = new Exception();
-        $promises = [Promise::reject($exception), Promise::resolve(2), Promise::reject($exception)];
+        $promises = [Promise\reject($exception), Promise\resolve(2), Promise\reject($exception)];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo(2));
         
-        Promise::any($promises)->done($callback, $this->createCallback(0));
+        Promise\any($promises)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testRejectIfAllInputPromisesAreRejected()
     {
         $exception = new Exception();
-        $promises = [Promise::reject($exception), Promise::reject($exception), Promise::reject($exception)];
+        $promises = [Promise\reject($exception), Promise\reject($exception), Promise\reject($exception)];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->isInstanceOf('Icicle\Promise\Exception\MultiReasonException'));
         
-        Promise::any($promises)->done($this->createCallback(0), $callback);
+        Promise\any($promises)->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testArrayKeysPreserved()
     {
         $exception = new Exception();
         $promises = [
-            'one' => Promise::reject($exception),
-            'two' => Promise::reject($exception),
-            'three' => Promise::reject($exception)
+            'one' => Promise\reject($exception),
+            'two' => Promise\reject($exception),
+            'three' => Promise\reject($exception)
         ];
         
         $callback = $this->createCallback(1);
@@ -100,8 +97,8 @@ class PromiseAnyTest extends TestCase
             return array_keys($reasons) === array_keys($promises);
         }));
         
-        Promise::any($promises)->done($this->createCallback(0), $callback);
+        Promise\any($promises)->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Promise/PromiseChooseTest.php
+++ b/tests/Promise/PromiseChooseTest.php
@@ -2,18 +2,15 @@
 namespace Icicle\Tests\Promise;
 
 use Exception;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Tests\TestCase;
 
-/**
- * @requires PHP 5.4
- */
 class PromiseChooseTest extends TestCase
 {
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
     
     public function testEmptyArray()
@@ -22,9 +19,9 @@ class PromiseChooseTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->isInstanceOf('Icicle\Promise\Exception\LogicException'));
         
-        Promise::choose([])->done($this->createCallback(0), $callback);
+        Promise\choose([])->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testValuesArray()
@@ -35,48 +32,48 @@ class PromiseChooseTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->identicalTo(1));
         
-        Promise::choose($values)->done($callback, $this->createCallback(0));
+        Promise\choose($values)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testPromisesArray()
     {
-        $promises = [Promise::resolve(1), Promise::resolve(2), Promise::resolve(3)];
+        $promises = [Promise\resolve(1), Promise\resolve(2), Promise\resolve(3)];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo(1));
         
-        Promise::choose($promises)->done($callback, $this->createCallback(0));
+        Promise\choose($promises)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testFulfillOnFirstFulfilled()
     {
-        $promises = [Promise::resolve(1)->delay(0.3), Promise::resolve(2)->delay(0.1), Promise::resolve(3)->delay(0.2)];
+        $promises = [Promise\resolve(1)->delay(0.3), Promise\resolve(2)->delay(0.1), Promise\resolve(3)->delay(0.2)];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo(2));
         
-        Promise::choose($promises)->done($callback, $this->createCallback(0));
+        Promise\choose($promises)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testRejectOnFirstRejected()
     {
         $exception = new Exception();
-        $promises = [Promise::resolve(1)->delay(0.2), Promise::reject($exception), Promise::resolve(3)->delay(0.1)];
+        $promises = [Promise\resolve(1)->delay(0.2), Promise\reject($exception), Promise\resolve(3)->delay(0.1)];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo($exception));
         
-        Promise::choose($promises)->done($this->createCallback(0), $callback);
+        Promise\choose($promises)->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Promise/PromiseJoinTest.php
+++ b/tests/Promise/PromiseJoinTest.php
@@ -2,18 +2,15 @@
 namespace Icicle\Tests\Promise;
 
 use Exception;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Tests\TestCase;
 
-/**
- * @requires PHP 5.4
- */
 class PromiseJoinTest extends TestCase
 {
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
     
     public function testEmptyArray()
@@ -22,9 +19,9 @@ class PromiseJoinTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->identicalTo([]));
         
-        Promise::join([])->done($callback, $this->createCallback(0));
+        Promise\join([])->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testValuesArray()
@@ -35,50 +32,50 @@ class PromiseJoinTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->equalTo($values));
         
-        Promise::join($values)->done($callback, $this->createCallback(0));
+        Promise\join($values)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testFulfilledPromisesArray()
     {
         $values = [1, 2, 3];
-        $promises = [Promise::resolve(1), Promise::resolve(2), Promise::resolve(3)];
+        $promises = [Promise\resolve(1), Promise\resolve(2), Promise\resolve(3)];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->equalTo($values));
         
-        Promise::join($promises)->done($callback, $this->createCallback(0));
+        Promise\join($promises)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testPendingPromisesArray()
     {
         $values = [1, 2, 3];
         $promises = [
-            Promise::resolve(1)->delay(0.2),
-            Promise::resolve(2)->delay(0.3),
-            Promise::resolve(3)->delay(0.1)
+            Promise\resolve(1)->delay(0.2),
+            Promise\resolve(2)->delay(0.3),
+            Promise\resolve(3)->delay(0.1)
         ];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->equalTo($values));
         
-        Promise::join($promises)->done($callback, $this->createCallback(0));
+        Promise\join($promises)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testArrayKeysPreserved()
     {
         $values = ['one' => 1, 'two' => 2, 'three' => 3];
         $promises = [
-            'one' => Promise::resolve(1)->delay(0.2),
-            'two' => Promise::resolve(2)->delay(0.3),
-            'three' => Promise::resolve(3)->delay(0.1)
+            'one' => Promise\resolve(1)->delay(0.2),
+            'two' => Promise\resolve(2)->delay(0.3),
+            'three' => Promise\resolve(3)->delay(0.1)
         ];
         
         $callback = $this->createCallback(1);
@@ -89,22 +86,22 @@ class PromiseJoinTest extends TestCase
             return array_keys($result) === array_keys($promises);
         }));
         
-        Promise::join($promises)->done($callback, $this->createCallback(0));
+        Promise\join($promises)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testRejectIfInputPromiseIsRejected()
     {
         $exception = new Exception();
-        $promises = [Promise::resolve(1), Promise::reject($exception), Promise::resolve(3)];
+        $promises = [Promise\resolve(1), Promise\reject($exception), Promise\resolve(3)];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo($exception));
         
-        Promise::join($promises)->done($this->createCallback(0), $callback);
+        Promise\join($promises)->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Promise/PromiseLiftTest.php
+++ b/tests/Promise/PromiseLiftTest.php
@@ -2,25 +2,22 @@
 namespace Icicle\Tests\Promise;
 
 use Exception;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Tests\TestCase;
 
-/**
- * @requires PHP 5.4
- */
 class PromiseLiftTest extends TestCase
 {
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
     
     public function testNoArguments()
     {
         $worker = function () { return 1; };
         
-        $lifted = Promise::lift($worker);
+        $lifted = Promise\lift($worker);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -28,7 +25,7 @@ class PromiseLiftTest extends TestCase
         
         $lifted()->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testValueArguments()
@@ -37,7 +34,7 @@ class PromiseLiftTest extends TestCase
             return $left - $right;
         };
         
-        $lifted = Promise::lift($worker);
+        $lifted = Promise\lift($worker);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -45,7 +42,7 @@ class PromiseLiftTest extends TestCase
         
         $lifted(1, 2)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testFulfilledPromiseArguments()
@@ -54,16 +51,16 @@ class PromiseLiftTest extends TestCase
             return $left - $right;
         };
         
-        $lifted = Promise::lift($worker);
+        $lifted = Promise\lift($worker);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo(-1));
         
-        $lifted(Promise::resolve(1), Promise::resolve(2))
+        $lifted(Promise\resolve(1), Promise\resolve(2))
             ->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testPendingPromiseArguments()
@@ -72,19 +69,19 @@ class PromiseLiftTest extends TestCase
             return $left - $right;
         };
         
-        $lifted = Promise::lift($worker);
+        $lifted = Promise\lift($worker);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo(-1));
         
         $lifted(
-            Promise::resolve(1)->delay(0.2),
-            Promise::resolve(2)->delay(0.1)
+            Promise\resolve(1)->delay(0.2),
+            Promise\resolve(2)->delay(0.1)
         )
         ->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testRejectedPromiseArguments()
@@ -95,27 +92,27 @@ class PromiseLiftTest extends TestCase
             return $left - $right;
         };
         
-        $lifted = Promise::lift($worker);
+        $lifted = Promise\lift($worker);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo($exception));
         
-        $lifted(Promise::resolve(1), Promise::reject($exception))
+        $lifted(Promise\resolve(1), Promise\reject($exception))
             ->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testLiftedFunctionReturnsPromise()
     {
-        $promise = Promise::resolve(1);
+        $promise = Promise\resolve(1);
         
         $worker = function () use ($promise) {
             return $promise;
         };
         
-        $lifted = Promise::lift($worker);
+        $lifted = Promise\lift($worker);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -123,7 +120,7 @@ class PromiseLiftTest extends TestCase
         
         $lifted()->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testRejectIfLiftedFunctionThrowsException()
@@ -134,7 +131,7 @@ class PromiseLiftTest extends TestCase
             throw $exception;
         };
         
-        $lifted = Promise::lift($worker);
+        $lifted = Promise\lift($worker);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -142,6 +139,6 @@ class PromiseLiftTest extends TestCase
         
         $lifted()->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Promise/PromiseMapTest.php
+++ b/tests/Promise/PromiseMapTest.php
@@ -17,7 +17,7 @@ class PromiseMapTest extends TestCase
     {
         $values = [];
         
-        $result = Promise\map($values, $this->createCallback(0));
+        $result = Promise\map($this->createCallback(0), $values);
         
         $this->assertSame($result, $values);
     }
@@ -32,7 +32,7 @@ class PromiseMapTest extends TestCase
             return $value + 1;
         };
         
-        $result = Promise\map($values, $callback);
+        $result = Promise\map($callback, $values);
         
         Loop\run();
         
@@ -57,7 +57,7 @@ class PromiseMapTest extends TestCase
             return $value + 1;
         };
         
-        $result = Promise\map($promises, $callback);
+        $result = Promise\map($callback, $promises);
         
         Loop\run();
         
@@ -84,7 +84,7 @@ class PromiseMapTest extends TestCase
             return $value + 1;
         };
         
-        $result = Promise\map($promises, $callback);
+        $result = Promise\map($callback, $promises);
         
         foreach ($result as $key => $promise) {
             $this->assertInstanceOf('Icicle\Promise\PromiseInterface', $promise);
@@ -112,7 +112,7 @@ class PromiseMapTest extends TestCase
             Promise\reject($exception)
         ];
         
-        $result = Promise\map($promises, $this->createCallback(0));
+        $result = Promise\map($this->createCallback(0), $promises);
         
         foreach ($result as $key => $promise) {
             $this->assertInstanceOf('Icicle\Promise\PromiseInterface', $promise);
@@ -133,7 +133,7 @@ class PromiseMapTest extends TestCase
         $callback->method('__invoke')
                  ->will($this->throwException($exception));
         
-        $result = Promise\map($values, $callback);
+        $result = Promise\map($callback, $values);
         
         foreach ($result as $key => $promise) {
             $this->assertInstanceOf('Icicle\Promise\PromiseInterface', $promise);

--- a/tests/Promise/PromiseMapTest.php
+++ b/tests/Promise/PromiseMapTest.php
@@ -2,25 +2,22 @@
 namespace Icicle\Tests\Promise;
 
 use Exception;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Tests\TestCase;
 
-/**
- * @requires PHP 5.4
- */
 class PromiseMapTest extends TestCase
 {
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
     
     public function testEmptyArray()
     {
         $values = [];
         
-        $result = Promise::map($values, $this->createCallback(0));
+        $result = Promise\map($values, $this->createCallback(0));
         
         $this->assertSame($result, $values);
     }
@@ -35,9 +32,9 @@ class PromiseMapTest extends TestCase
             return $value + 1;
         };
         
-        $result = Promise::map($values, $callback);
+        $result = Promise\map($values, $callback);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue(is_array($result));
         
@@ -52,7 +49,7 @@ class PromiseMapTest extends TestCase
      */
     public function testFulfilledPromisesArray()
     {
-        $promises = [Promise::resolve(1), Promise::resolve(2), Promise::resolve(3)];
+        $promises = [Promise\resolve(1), Promise\resolve(2), Promise\resolve(3)];
         
         $callback = $this->createCallback(3);
         $callback = function ($value) use ($callback) {
@@ -60,9 +57,9 @@ class PromiseMapTest extends TestCase
             return $value + 1;
         };
         
-        $result = Promise::map($promises, $callback);
+        $result = Promise\map($promises, $callback);
         
-        Loop::run();
+        Loop\run();
         
         foreach ($result as $key => $promise) {
             $this->assertInstanceOf('Icicle\Promise\PromiseInterface', $promise);
@@ -76,9 +73,9 @@ class PromiseMapTest extends TestCase
     public function testPendingPromisesArray()
     {
         $promises = [
-            Promise::resolve(1)->delay(0.2),
-            Promise::resolve(2)->delay(0.3),
-            Promise::resolve(3)->delay(0.1)
+            Promise\resolve(1)->delay(0.2),
+            Promise\resolve(2)->delay(0.3),
+            Promise\resolve(3)->delay(0.1)
         ];
         
         $callback = $this->createCallback(3);
@@ -87,14 +84,14 @@ class PromiseMapTest extends TestCase
             return $value + 1;
         };
         
-        $result = Promise::map($promises, $callback);
+        $result = Promise\map($promises, $callback);
         
         foreach ($result as $key => $promise) {
             $this->assertInstanceOf('Icicle\Promise\PromiseInterface', $promise);
             $this->assertTrue($promise->isPending());
         }
         
-        Loop::run();
+        Loop\run();
         
         foreach ($result as $key => $promise) {
             $this->assertTrue($promise->isFulfilled());
@@ -110,12 +107,12 @@ class PromiseMapTest extends TestCase
         $exception = new Exception();
         
         $promises = [
-            Promise::reject($exception),
-            Promise::reject($exception),
-            Promise::reject($exception)
+            Promise\reject($exception),
+            Promise\reject($exception),
+            Promise\reject($exception)
         ];
         
-        $result = Promise::map($promises, $this->createCallback(0));
+        $result = Promise\map($promises, $this->createCallback(0));
         
         foreach ($result as $key => $promise) {
             $this->assertInstanceOf('Icicle\Promise\PromiseInterface', $promise);
@@ -136,14 +133,14 @@ class PromiseMapTest extends TestCase
         $callback->method('__invoke')
                  ->will($this->throwException($exception));
         
-        $result = Promise::map($values, $callback);
+        $result = Promise\map($values, $callback);
         
         foreach ($result as $key => $promise) {
             $this->assertInstanceOf('Icicle\Promise\PromiseInterface', $promise);
             $this->assertTrue($promise->isPending());
         }
         
-        Loop::run();
+        Loop\run();
         
         foreach ($result as $key => $promise) {
             $this->assertTrue($promise->isRejected());

--- a/tests/Promise/PromisePromisifyTest.php
+++ b/tests/Promise/PromisePromisifyTest.php
@@ -2,18 +2,15 @@
 namespace Icicle\Tests\Promise;
 
 use Exception;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Tests\TestCase;
 
-/**
- * @requires PHP 5.4
- */
 class PromisePromisifyTest extends TestCase
 {
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
     
     public function testFunctionOnlyTakingACallback()
@@ -22,7 +19,7 @@ class PromisePromisifyTest extends TestCase
             return $callback(1, 2, 3);
         };
         
-        $promisified = Promise::promisify($worker);
+        $promisified = Promise\promisify($worker);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -30,7 +27,7 @@ class PromisePromisifyTest extends TestCase
         
         $promisified()->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testFunctionWithCallbackAsFirstParameter()
@@ -39,7 +36,7 @@ class PromisePromisifyTest extends TestCase
             return $callback($value1, $value2, $value3);
         };
         
-        $promisified = Promise::promisify($worker);
+        $promisified = Promise\promisify($worker);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -47,7 +44,7 @@ class PromisePromisifyTest extends TestCase
         
         $promisified(1, 2, 3)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testFunctionWithCallbackAsMidParameter()
@@ -56,7 +53,7 @@ class PromisePromisifyTest extends TestCase
             return $callback($value1, $value2, $value3);
         };
         
-        $promisified = Promise::promisify($worker, 1);
+        $promisified = Promise\promisify($worker, 1);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -64,7 +61,7 @@ class PromisePromisifyTest extends TestCase
         
         $promisified(1, 2, 3)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testFunctionWithCallbackAsLastParameter()
@@ -73,7 +70,7 @@ class PromisePromisifyTest extends TestCase
             return $callback($value1, $value2, $value3);
         };
         
-        $promisified = Promise::promisify($worker, 3);
+        $promisified = Promise\promisify($worker, 3);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -81,76 +78,9 @@ class PromisePromisifyTest extends TestCase
         
         $promisified(1, 2, 3)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
-    
-/*
-    public function testFulfilledPromisesAsArguments()
-    {
-        $worker = function ($value1, $value2, $value3, callable $callback) {
-            return $callback($value1, $value2, $value3);
-        };
-        
-        $promisified = Promise::promisify($worker, 3);
-        
-        $callback = $this->createCallback(1);
-        $callback->method('__invoke')
-                 ->with($this->identicalTo([1, 2, 3]));
-        
-        $promisified(
-            Promise::resolve(1),
-            Promise::resolve(2),
-            Promise::resolve(3)
-        )->done($callback, $this->createCallback(0));
-        
-        Loop::run();
-    }
-    
-    public function testPendingPromisesAsArguments()
-    {
-        $worker = function ($value1, $value2, $value3, callable $callback) {
-            return $callback($value1, $value2, $value3);
-        };
-        
-        $promisified = Promise::promisify($worker, 3);
-        
-        $callback = $this->createCallback(1);
-        $callback->method('__invoke')
-                 ->with($this->identicalTo([1, 2, 3]));
-        
-        $promisified(
-            Promise::resolve(1)->delay(0.2),
-            Promise::resolve(2)->delay(0.3),
-            Promise::resolve(3)->delay(0.1)
-        )->done($callback, $this->createCallback(0));
-        
-        Loop::run();
-    }
-    
-    public function testRejectedPromisesAsArguments()
-    {
-        $exception = new Exception();
-        
-        $worker = function ($value1, $value2, $value3, callable $callback) {
-            return $callback($value1, $value2, $value3);
-        };
-        
-        $promisified = Promise::promisify($worker, 3);
-        
-        $callback = $this->createCallback(1);
-        $callback->method('__invoke')
-                 ->with($this->identicalTo($exception));
-        
-        $promisified(
-            Promise::resolve(1),
-            Promise::reject($exception),
-            Promise::resolve(3)
-        )->done($this->createCallback(0), $callback);
-        
-        Loop::run();
-    }
-*/
-    
+
     public function testReturnedPromiseRejectedWhenWorkerThrowsException()
     {
         $exception = new Exception();
@@ -159,7 +89,7 @@ class PromisePromisifyTest extends TestCase
             throw $exception;
         };
         
-        $promisified = Promise::promisify($worker);
+        $promisified = Promise\promisify($worker);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -167,7 +97,7 @@ class PromisePromisifyTest extends TestCase
         
         $promisified()->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testTooFewArguments()
@@ -176,7 +106,7 @@ class PromisePromisifyTest extends TestCase
             return $callback($value1, $value2);
         };
         
-        $promisified = Promise::promisify($worker, 2);
+        $promisified = Promise\promisify($worker, 2);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -184,6 +114,6 @@ class PromisePromisifyTest extends TestCase
         
         $promisified()->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Promise/PromiseReduceTest.php
+++ b/tests/Promise/PromiseReduceTest.php
@@ -2,18 +2,15 @@
 namespace Icicle\Tests\Promise;
 
 use Exception;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Tests\TestCase;
 
-/**
- * @requires PHP 5.4
- */
 class PromiseReduceTest extends TestCase
 {
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
     
     public function testEmptyArrayWithNoInitial()
@@ -22,10 +19,10 @@ class PromiseReduceTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->identicalTo(null));
         
-        Promise::reduce([], $this->createCallback(0))
+        Promise\reduce([], $this->createCallback(0))
                ->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testEmptyArrayWithInitial()
@@ -36,10 +33,10 @@ class PromiseReduceTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->identicalTo($initial));
         
-        Promise::reduce([], $this->createCallback(0), $initial)
+        Promise\reduce([], $this->createCallback(0), $initial)
                ->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testValuesArray()
@@ -50,79 +47,79 @@ class PromiseReduceTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->identicalTo(6));
         
-        Promise::reduce($values, function ($carry, $value) { return $carry + $value; }, 0)
+        Promise\reduce($values, function ($carry, $value) { return $carry + $value; }, 0)
                ->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testPromisesArray()
     {
-        $promises = [Promise::resolve(1), Promise::resolve(2), Promise::resolve(3)];
+        $promises = [Promise\resolve(1), Promise\resolve(2), Promise\resolve(3)];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo(6));
         
-        Promise::reduce($promises, function ($carry, $value) { return $carry + $value; }, 0)
+        Promise\reduce($promises, function ($carry, $value) { return $carry + $value; }, 0)
                ->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testPendingPromisesArray()
     {
         $promises = [
-            Promise::resolve(1)->delay(0.2),
-            Promise::resolve(2)->delay(0.3),
-            Promise::resolve(3)->delay(0.1)
+            Promise\resolve(1)->delay(0.2),
+            Promise\resolve(2)->delay(0.3),
+            Promise\resolve(3)->delay(0.1)
         ];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo(6));
         
-        Promise::reduce($promises, function ($carry, $value) { return $carry + $value; }, 0)
+        Promise\reduce($promises, function ($carry, $value) { return $carry + $value; }, 0)
                ->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testFulfilledPromiseAsInitial()
     {
         $values = [1, 2, 3];
-        $initial = Promise::resolve(4);
+        $initial = Promise\resolve(4);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo(10));
         
-        Promise::reduce($values, function ($carry, $value) { return $carry + $value; }, $initial)
+        Promise\reduce($values, function ($carry, $value) { return $carry + $value; }, $initial)
                ->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testRejectedPromiseAsInitial()
     {
         $exception = new Exception();
         $values = [1, 2, 3];
-        $initial = Promise::reject($exception);
+        $initial = Promise\reject($exception);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo($exception));
         
-        Promise::reduce($values, function ($carry, $value) { return $carry + $value; }, $initial)
+        Promise\reduce($values, function ($carry, $value) { return $carry + $value; }, $initial)
                ->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testRejectOnFirstRejected()
     {
         $exception = new Exception();
-        $promises = [Promise::resolve(1), Promise::reject($exception), Promise::resolve(3)];
+        $promises = [Promise\resolve(1), Promise\reject($exception), Promise\resolve(3)];
         
         $mapper = function ($value) { return $value; };
         
@@ -130,61 +127,61 @@ class PromiseReduceTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->identicalTo($exception));
         
-        Promise::reduce($promises, function() {}, 0)
+        Promise\reduce($promises, function() {}, 0)
                ->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testCallbackReturnsFulfilledPromise()
     {
-        $promises = [Promise::resolve(1), Promise::resolve(2), Promise::resolve(3)];
+        $promises = [Promise\resolve(1), Promise\resolve(2), Promise\resolve(3)];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo(6));
         
-        Promise::reduce(
+        Promise\reduce(
             $promises,
             function ($carry, $value) {
-                return Promise::resolve($carry + $value);
+                return Promise\resolve($carry + $value);
             },
             0
         )->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testCallbackReturnsRejectedPromise()
     {
         $exception = new Exception();
-        $promises = [Promise::resolve(1), Promise::resolve(2)];
+        $promises = [Promise\resolve(1), Promise\resolve(2)];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo($exception));
         
-        Promise::reduce(
+        Promise\reduce(
             $promises,
             function () use ($exception) {
-                return Promise::reject($exception);
+                return Promise\reject($exception);
             },
             0
         )->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testCallbackThrowsException()
     {
         $exception = new Exception();
-        $promises = [Promise::resolve(1), Promise::resolve(2)];
+        $promises = [Promise\resolve(1), Promise\resolve(2)];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo($exception));
         
-        Promise::reduce(
+        Promise\reduce(
             $promises,
             function ($carry, $value) use ($exception) {
                 throw $exception;
@@ -192,6 +189,6 @@ class PromiseReduceTest extends TestCase
             0
         )->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Promise/PromiseRetryTest.php
+++ b/tests/Promise/PromiseRetryTest.php
@@ -2,20 +2,17 @@
 namespace Icicle\Tests\Promise;
 
 use Exception;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Tests\TestCase;
 
-/**
- * @requires PHP 5.4
- */
 class PromiseRetryTest extends TestCase
 {
     const TIMEOUT = 0.1;
     
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
     
     public function testPromisorReturningScalar()
@@ -23,17 +20,17 @@ class PromiseRetryTest extends TestCase
         $value = 'testing';
         
         $promisor = function () use ($value) {
-            return Promise::resolve($value);
+            return Promise\resolve($value);
         };
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo($value));
         
-        Promise::retry($promisor, $this->createCallback(0))
+        Promise\retry($promisor, $this->createCallback(0))
             ->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testPromisorReturnsFulfilledPromise()
@@ -41,17 +38,17 @@ class PromiseRetryTest extends TestCase
         $value = 'testing';
         
         $promisor = function () use ($value) {
-            return Promise::resolve($value);
+            return Promise\resolve($value);
         };
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo($value));
         
-        Promise::retry($promisor, $this->createCallback(0))
+        Promise\retry($promisor, $this->createCallback(0))
             ->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testPromisorReturnsPendingPromise()
@@ -59,17 +56,17 @@ class PromiseRetryTest extends TestCase
         $value = 'testing';
         
         $promisor = function () use ($value) {
-            return Promise::resolve($value)->delay(self::TIMEOUT);
+            return Promise\resolve($value)->delay(self::TIMEOUT);
         };
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->identicalTo($value));
         
-        Promise::retry($promisor, $this->createCallback(0))
+        Promise\retry($promisor, $this->createCallback(0))
             ->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testPromisorThrowsException()
@@ -84,10 +81,10 @@ class PromiseRetryTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->identicalTo($exception));
         
-        Promise::retry($promisor, $this->createCallback(0))
+        Promise\retry($promisor, $this->createCallback(0))
             ->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testPromiseRejectingCallsOnRejected()
@@ -95,7 +92,7 @@ class PromiseRetryTest extends TestCase
         $exception = new Exception();
         
         $promisor = function () use ($exception) {
-            return Promise::reject($exception);
+            return Promise\reject($exception);
         };
         
         $onRejected = function ($value) use ($exception) {
@@ -107,10 +104,10 @@ class PromiseRetryTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->identicalTo($exception));
         
-        Promise::retry($promisor, $onRejected)
+        Promise\retry($promisor, $onRejected)
             ->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -121,7 +118,7 @@ class PromiseRetryTest extends TestCase
         $exception = new Exception();
         
         $promisor = function () use ($exception) {
-            $promise = new Promise(function () {});
+            $promise = new Promise\Promise(function () {});
             return $promise->timeout(self::TIMEOUT, $exception);
         };
         
@@ -134,10 +131,10 @@ class PromiseRetryTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->identicalTo($exception));
         
-        Promise::retry($promisor, $onRejected)
+        Promise\retry($promisor, $onRejected)
             ->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -148,7 +145,7 @@ class PromiseRetryTest extends TestCase
         $exception = new Exception();
         
         $promisor = function () {
-            return Promise::reject();
+            return Promise\reject();
         };
         
         $onRejected = function () use ($exception) {
@@ -159,10 +156,10 @@ class PromiseRetryTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->identicalTo($exception));
         
-        Promise::retry($promisor, $onRejected)
+        Promise\retry($promisor, $onRejected)
             ->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -177,10 +174,10 @@ class PromiseRetryTest extends TestCase
             static $initial = true;
             if ($initial) {
                 $initial = false;
-                return Promise::reject($exception);
+                return Promise\reject($exception);
             }
             
-            return Promise::resolve($value);
+            return Promise\resolve($value);
         };
         
         $onRejected = function ($value) use ($exception) {
@@ -192,10 +189,10 @@ class PromiseRetryTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->identicalTo($value));
         
-        Promise::retry($promisor, $onRejected)
+        Promise\retry($promisor, $onRejected)
             ->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -210,7 +207,7 @@ class PromiseRetryTest extends TestCase
             static $initial = true;
             if ($initial) {
                 $initial = false;
-                return Promise::reject($exception1);
+                return Promise\reject($exception1);
             }
             
             throw $exception2;
@@ -225,10 +222,10 @@ class PromiseRetryTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->identicalTo($exception2));
         
-        Promise::retry($promisor, $onRejected)
+        Promise\retry($promisor, $onRejected)
             ->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -239,7 +236,7 @@ class PromiseRetryTest extends TestCase
         $exception = new Exception();
 
         $promisor = function () use ($exception) {
-            return Promise::reject($exception);
+            return Promise\reject($exception);
         };
 
         $onRejected = function () {};
@@ -248,10 +245,10 @@ class PromiseRetryTest extends TestCase
         $callback->method('__invoke')
             ->with($this->identicalTo($exception));
 
-        Promise::retry($promisor, $onRejected)
+        Promise\retry($promisor, $onRejected)
             ->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     public function testInitialPromiseCancelledOnCancellation()
@@ -260,7 +257,7 @@ class PromiseRetryTest extends TestCase
 
         $exception = new Exception();
 
-        $promise = Promise::resolve()->delay($delay * 2);
+        $promise = Promise\resolve()->delay($delay * 2);
 
         $promisor = function () use ($promise) {
             return $promise;
@@ -272,10 +269,10 @@ class PromiseRetryTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        $promise = Promise::retry($promisor, $this->createCallback(0));
-        Loop::timer($delay, [$promise, 'cancel'], $exception);
+        $promise = Promise\retry($promisor, $this->createCallback(0));
+        Loop\timer($delay, [$promise, 'cancel'], $exception);
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -288,13 +285,13 @@ class PromiseRetryTest extends TestCase
         $exception = new Exception();
         $reason = new Exception();
 
-        $promise = Promise::resolve()->delay($delay * 2);
+        $promise = Promise\resolve()->delay($delay * 2);
 
         $promisor = function () use ($promise, $reason) {
             static $initial = true;
             if ($initial) {
                 $initial = false;
-                return Promise::reject($reason);
+                return Promise\reject($reason);
             } else {
                 return $promise;
             }
@@ -315,9 +312,9 @@ class PromiseRetryTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        $promise = Promise::retry($promisor, $onRejected);
-        Loop::timer($delay, [$promise, 'cancel'], $exception);
+        $promise = Promise\retry($promisor, $onRejected);
+        Loop\timer($delay, [$promise, 'cancel'], $exception);
 
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Promise/PromiseSettleTest.php
+++ b/tests/Promise/PromiseSettleTest.php
@@ -2,18 +2,15 @@
 namespace Icicle\Tests\Promise;
 
 use Exception;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Tests\TestCase;
 
-/**
- * @requires PHP 5.4
- */
 class PromiseSettleTest extends TestCase
 {
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
     
     public function testEmptyArray()
@@ -22,9 +19,9 @@ class PromiseSettleTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->identicalTo([]));
         
-        Promise::settle([])->done($callback, $this->createCallback(0));
+        Promise\settle([])->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testValuesArray()
@@ -42,48 +39,48 @@ class PromiseSettleTest extends TestCase
             return true;
         }));
         
-        Promise::settle($values)->done($callback, $this->createCallback(0));
+        Promise\settle($values)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testFulfilledPromisesArray()
     {
-        $promises = [Promise::resolve(1), Promise::resolve(2), Promise::resolve(3)];
+        $promises = [Promise\resolve(1), Promise\resolve(2), Promise\resolve(3)];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->equalTo($promises));
         
-        Promise::settle($promises)->done($callback, $this->createCallback(0));
+        Promise\settle($promises)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testPendingPromisesArray()
     {
         $promises = [
-            Promise::resolve(1)->delay(0.2),
-            Promise::resolve(2)->delay(0.3),
-            Promise::resolve(3)->delay(0.1)
+            Promise\resolve(1)->delay(0.2),
+            Promise\resolve(2)->delay(0.3),
+            Promise\resolve(3)->delay(0.1)
         ];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->equalTo($promises));
         
-        Promise::settle($promises)->done($callback, $this->createCallback(0));
+        Promise\settle($promises)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testArrayKeysPreserved()
     {
         $values = ['one' => 1, 'two' => 2, 'three' => 3];
         $promises = [
-            'one' => Promise::resolve(1)->delay(0.2),
-            'two' => Promise::resolve(2)->delay(0.3),
-            'three' => Promise::resolve(3)->delay(0.1)
+            'one' => Promise\resolve(1)->delay(0.2),
+            'two' => Promise\resolve(2)->delay(0.3),
+            'three' => Promise\resolve(3)->delay(0.1)
         ];
         
         $callback = $this->createCallback(1);
@@ -94,26 +91,26 @@ class PromiseSettleTest extends TestCase
             return array_keys($result) === array_keys($promises);
         }));
         
-        Promise::settle($promises)->done($callback, $this->createCallback(0));
+        Promise\settle($promises)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testFulfilledWithRejectedInputPromises()
     {
         $exception = new Exception();
         $promises = [
-            Promise::resolve(1)->delay(0.1),
-            Promise::reject($exception), 
-            Promise::resolve(3)
+            Promise\resolve(1)->delay(0.1),
+            Promise\reject($exception), 
+            Promise\resolve(3)
         ];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->equalTo($promises));
         
-        Promise::settle($promises)->done($callback, $this->createCallback(0));
+        Promise\settle($promises)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Promise/PromiseSomeTest.php
+++ b/tests/Promise/PromiseSomeTest.php
@@ -2,18 +2,15 @@
 namespace Icicle\Tests\Promise;
 
 use Exception;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Tests\TestCase;
 
-/**
- * @requires PHP 5.4
- */
 class PromiseSomeTest extends TestCase
 {
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
     
     public function testEmptyArray()
@@ -22,9 +19,9 @@ class PromiseSomeTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->isInstanceOf('Icicle\Promise\Exception\LogicException'));
         
-        Promise::some([], 1)->done($this->createCallback(0), $callback);
+        Promise\some([], 1)->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testRequireZeroFulfillsWithEmptyArray()
@@ -33,9 +30,9 @@ class PromiseSomeTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->identicalTo([]));
         
-        Promise::some([1], 0)->done($callback, $this->createCallback(0));
+        Promise\some([1], 0)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testValuesArray()
@@ -44,84 +41,84 @@ class PromiseSomeTest extends TestCase
         $callback->method('__invoke')
                  ->with($this->equalTo([1, 2]));
         
-        Promise::some([1, 2, 3], 2)->done($callback, $this->createCallback(0));
+        Promise\some([1, 2, 3], 2)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testFulfilledPromisesArray()
     {
         $values = [1, 2, 3];
-        $promises = [Promise::resolve(1), Promise::resolve(2), Promise::resolve(3)];
+        $promises = [Promise\resolve(1), Promise\resolve(2), Promise\resolve(3)];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->equalTo([0 => 1, 1 => 2]));
         
-        Promise::some($promises, 2)->done($callback, $this->createCallback(0));
+        Promise\some($promises, 2)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testPendingPromisesArray()
     {
         $values = [1, 2, 3];
         $promises = [
-            Promise::resolve(1)->delay(0.2),
-            Promise::resolve(2)->delay(0.3),
-            Promise::resolve(3)->delay(0.1)
+            Promise\resolve(1)->delay(0.2),
+            Promise\resolve(2)->delay(0.3),
+            Promise\resolve(3)->delay(0.1)
         ];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->equalTo([0 => 1, 2 => 3]));
         
-        Promise::some($promises, 2)->done($callback, $this->createCallback(0));
+        Promise\some($promises, 2)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testRejectIfTooManyPromisesAreRejected()
     {
         $exception = new Exception();
-        $promises = [Promise::reject($exception), Promise::resolve(2), Promise::reject($exception)];
+        $promises = [Promise\reject($exception), Promise\resolve(2), Promise\reject($exception)];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->isInstanceOf('Icicle\Promise\Exception\MultiReasonException'));
         
-        Promise::some($promises, 2)->done($this->createCallback(0), $callback);
+        Promise\some($promises, 2)->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testFulfillImmediatelyWhenEnoughPromisesAreFulfilled()
     {
         $exception = new Exception();
         $promises = [
-            Promise::reject($exception),
-            Promise::resolve(2),
-            Promise::reject($exception),
-            Promise::resolve(4),
-            Promise::resolve(5)
+            Promise\reject($exception),
+            Promise\resolve(2),
+            Promise\reject($exception),
+            Promise\resolve(4),
+            Promise\resolve(5)
         ];
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
                  ->with($this->equalTo([1 => 2, 3 => 4]));
         
-        Promise::some($promises, 2)->done($callback, $this->createCallback(0));
+        Promise\some($promises, 2)->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testArrayKeysPreservedOnRejected()
     {
         $exception = new Exception();
         $promises = [
-            'one' => Promise::reject($exception),
-            'two' => Promise::resolve(2),
-            'three' => Promise::reject($exception)
+            'one' => Promise\reject($exception),
+            'two' => Promise\resolve(2),
+            'three' => Promise\reject($exception)
         ];
         
         $callback = $this->createCallback(1);
@@ -132,8 +129,8 @@ class PromiseSomeTest extends TestCase
             return array_keys($reasons) === ['one', 'three'];
         }));
         
-        Promise::some($promises, 2)->done($this->createCallback(0), $callback);
+        Promise\some($promises, 2)->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Promise/PromiseTest.php
+++ b/tests/Promise/PromiseTest.php
@@ -2,9 +2,9 @@
 namespace Icicle\Tests\Promise;
 
 use Exception;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Promise\Exception\LogicException;
-use Icicle\Promise\Promise;
+use Icicle\Promise;
 use Icicle\Tests\TestCase;
 use InvalidArgumentException;
 use RuntimeException;
@@ -28,7 +28,7 @@ class PromiseTest extends TestCase
     
     public function setUp()
     {
-        $this->promise = new Promise(function ($resolve, $reject) {
+        $this->promise = new Promise\Promise(function ($resolve, $reject) {
             $this->resolve = $resolve;
             $this->reject = $reject;
         });
@@ -58,7 +58,7 @@ class PromiseTest extends TestCase
     {
         $exception = new Exception();
         
-        $promise = new Promise(function () use ($exception) {
+        $promise = new Promise\Promise(function () use ($exception) {
             throw $exception;
         });
         
@@ -74,10 +74,10 @@ class PromiseTest extends TestCase
     
     public function testResolve()
     {
-        $this->assertSame($this->promise, Promise::resolve($this->promise));
+        $this->assertSame($this->promise, Promise\resolve($this->promise));
         
         $value = 'test';
-        $fulfilled = Promise::resolve($value);
+        $fulfilled = Promise\resolve($value);
         
         $this->assertInstanceOf('Icicle\Promise\PromiseInterface', $fulfilled);
         
@@ -91,7 +91,7 @@ class PromiseTest extends TestCase
     {
         $exception = new Exception();
         
-        $rejected = Promise::reject($exception);
+        $rejected = Promise\reject($exception);
         
         $this->assertInstanceOf('Icicle\Promise\PromiseInterface', $rejected);
         
@@ -108,7 +108,7 @@ class PromiseTest extends TestCase
     {
         $reason = 'String to reject promise.';
         
-        $rejected = Promise::reject($reason);
+        $rejected = Promise\reject($reason);
         
         $this->assertInstanceOf('Icicle\Promise\PromiseInterface', $rejected);
         
@@ -129,7 +129,7 @@ class PromiseTest extends TestCase
     {
         $reason = new \stdClass();
         
-        $rejected = Promise::reject($reason);
+        $rejected = Promise\reject($reason);
         
         $result = $rejected->getResult();
         
@@ -143,7 +143,7 @@ class PromiseTest extends TestCase
     {
         $reason = [1, 2, 3];
         
-        $rejected = Promise::reject($reason);
+        $rejected = Promise\reject($reason);
         
         $result = $rejected->getResult();
         
@@ -157,7 +157,7 @@ class PromiseTest extends TestCase
     {
         $reason = 404;
         
-        $rejected = Promise::reject($reason);
+        $rejected = Promise\reject($reason);
         
         $result = $rejected->getResult();
         
@@ -171,7 +171,7 @@ class PromiseTest extends TestCase
     {
         $reason = 3.14159;
         
-        $rejected = Promise::reject($reason);
+        $rejected = Promise\reject($reason);
         
         $result = $rejected->getResult();
         
@@ -185,7 +185,7 @@ class PromiseTest extends TestCase
     {
         $reason = false;
         
-        $rejected = Promise::reject($reason);
+        $rejected = Promise\reject($reason);
         
         $result = $rejected->getResult();
         
@@ -204,7 +204,7 @@ class PromiseTest extends TestCase
         
         $this->resolve($value);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertFalse($this->promise->isPending());
         $this->assertTrue($this->promise->isFulfilled());
@@ -219,7 +219,7 @@ class PromiseTest extends TestCase
         $value = 'test';
         $this->resolve($value);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertInstanceOf('Icicle\Promise\PromiseInterface', $this->promise->then());
     }
@@ -243,7 +243,7 @@ class PromiseTest extends TestCase
         $this->resolve($value2);
         $this->reject($exception);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($this->promise->isFulfilled());
         $this->assertSame($value1, $this->promise->getResult());
@@ -256,7 +256,7 @@ class PromiseTest extends TestCase
     public function testResolveCallableWithFulfilledPromise()
     {
         $value = 'test';
-        $fulfilled = Promise::resolve($value);
+        $fulfilled = Promise\resolve($value);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -266,7 +266,7 @@ class PromiseTest extends TestCase
         
         $this->resolve($fulfilled);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($this->promise->isFulfilled());
         $this->assertSame($value, $this->promise->getResult());
@@ -278,7 +278,7 @@ class PromiseTest extends TestCase
     public function testResolveCallableWithRejectedPromise()
     {
         $exception = new Exception();
-        $rejected = Promise::reject($exception);
+        $rejected = Promise\reject($exception);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -288,7 +288,7 @@ class PromiseTest extends TestCase
         
         $this->resolve($rejected);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($this->promise->isRejected());
     }
@@ -299,11 +299,11 @@ class PromiseTest extends TestCase
      */
     public function testResolveCallableWithPendingPromise()
     {
-        $promise = new Promise(function () {});
+        $promise = new Promise\Promise(function () {});
         
         $this->resolve($promise);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($this->promise->isPending());
     }
@@ -315,17 +315,17 @@ class PromiseTest extends TestCase
     {
         $value = 'test';
         
-        $promise = new Promise(function ($resolve) use (&$pendingResolve) {
+        $promise = new Promise\Promise(function ($resolve) use (&$pendingResolve) {
             $pendingResolve = $resolve;
         });
         
         $this->resolve($promise);
         
-        Loop::run();
+        Loop\run();
         
         $pendingResolve($value);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($this->promise->isFulfilled());
         $this->assertSame($value, $this->promise->getResult());
@@ -339,17 +339,17 @@ class PromiseTest extends TestCase
     {
         $exception = new Exception();
         
-        $promise = new Promise(function ($resolve, $reject) use (&$pendingReject) {
+        $promise = new Promise\Promise(function ($resolve, $reject) use (&$pendingReject) {
             $pendingReject = $reject;
         });
         
         $this->resolve($promise);
         
-        Loop::run();
+        Loop\run();
         
         $pendingReject($exception);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($this->promise->isRejected());
         $this->assertSame($exception, $this->promise->getResult());
@@ -372,7 +372,7 @@ class PromiseTest extends TestCase
      */
     public function testResolveWithCircularReferenceRejectsPromise()
     {
-        $promise = new Promise(function ($resolve) use (&$pendingResolve) {
+        $promise = new Promise\Promise(function ($resolve) use (&$pendingResolve) {
             $pendingResolve = $resolve;
         });
         
@@ -382,11 +382,11 @@ class PromiseTest extends TestCase
         
         $pendingResolve($child);
         
-        Loop::run();
+        Loop\run();
         
         $this->resolve();
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($child->isRejected());
         $this->assertInstanceOf('Icicle\Promise\Exception\TypeException', $child->getResult());
@@ -407,7 +407,7 @@ class PromiseTest extends TestCase
         
         $this->reject($exception);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertFalse($this->promise->isPending());
         $this->assertTrue($this->promise->isRejected());
@@ -429,7 +429,7 @@ class PromiseTest extends TestCase
         
         $this->reject($reason);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertFalse($this->promise->isPending());
         $this->assertTrue($this->promise->isRejected());
@@ -444,7 +444,7 @@ class PromiseTest extends TestCase
         $exception = new Exception();
         $this->reject($exception);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertInstanceOf('Icicle\Promise\PromiseInterface', $this->promise->then());
     }
@@ -468,7 +468,7 @@ class PromiseTest extends TestCase
         $this->resolve($value);
         $this->reject($exception2);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($this->promise->isRejected());
         $this->assertSame($exception1, $this->promise->getResult());
@@ -482,7 +482,7 @@ class PromiseTest extends TestCase
         $value = 'test';
         $this->resolve($value);
         
-        Loop::run();
+        Loop\run();
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -490,7 +490,7 @@ class PromiseTest extends TestCase
         
         $this->promise->then($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -501,7 +501,7 @@ class PromiseTest extends TestCase
         $value = 'test';
         $this->resolve($value);
         
-        Loop::run();
+        Loop\run();
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -509,7 +509,7 @@ class PromiseTest extends TestCase
         
         $this->promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -520,7 +520,7 @@ class PromiseTest extends TestCase
         $exception = new Exception();
         $this->reject($exception);
         
-        Loop::run();
+        Loop\run();
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -528,7 +528,7 @@ class PromiseTest extends TestCase
         
         $this->promise->then($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -539,7 +539,7 @@ class PromiseTest extends TestCase
         $exception = new Exception();
         $this->reject($exception);
         
-        Loop::run();
+        Loop\run();
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -547,7 +547,7 @@ class PromiseTest extends TestCase
         
         $this->promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -561,7 +561,7 @@ class PromiseTest extends TestCase
         
         $this->resolve($value);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($child->isFulfilled());
         $this->assertSame($value, $child->getResult());
@@ -584,7 +584,7 @@ class PromiseTest extends TestCase
         
         $this->resolve($value1);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame($value1, $parameter);
         $this->assertTrue($child->isFulfilled());
@@ -608,7 +608,7 @@ class PromiseTest extends TestCase
         
         $this->reject($exception);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame($exception, $parameter);
         $this->assertTrue($child->isFulFilled());
@@ -632,7 +632,7 @@ class PromiseTest extends TestCase
         
         $this->resolve($value);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame($value, $parameter);
         $this->assertTrue($child->isRejected());
@@ -656,7 +656,7 @@ class PromiseTest extends TestCase
         
         $this->reject($exception1);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame($exception1, $parameter);
         $this->assertTrue($child->isRejected());
@@ -680,7 +680,7 @@ class PromiseTest extends TestCase
         
         $child = $this->promise->then($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame($value1, $parameter);
         $this->assertTrue($child->isFulfilled());
@@ -704,7 +704,7 @@ class PromiseTest extends TestCase
         
         $child = $this->promise->then($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame($exception, $parameter);
         $this->assertTrue($child->isFulFilled());
@@ -728,7 +728,7 @@ class PromiseTest extends TestCase
         
         $child = $this->promise->then($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame($value, $parameter);
         $this->assertTrue($child->isRejected());
@@ -752,7 +752,7 @@ class PromiseTest extends TestCase
         
         $child = $this->promise->then($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame($exception1, $parameter);
         $this->assertTrue($child->isRejected());
@@ -776,7 +776,7 @@ class PromiseTest extends TestCase
         
         $this->resolve($value);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($child->isFulfilled());
         $this->assertSame($value, $child->getResult());
@@ -800,7 +800,7 @@ class PromiseTest extends TestCase
         
         $this->reject($exception);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($child->isRejected());
         $this->assertSame($exception, $child->getResult());
@@ -818,14 +818,14 @@ class PromiseTest extends TestCase
         
         $callback = function ($value) use (&$parameter, $value2) {
             $parameter = $value;
-            return Promise::resolve($value2);
+            return Promise\resolve($value2);
         };
         
         $child = $this->promise->then($callback, $this->createCallback(0));
         
         $this->resolve($value1);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame($value1, $parameter);
         $this->assertTrue($child->isFulfilled());
@@ -843,14 +843,14 @@ class PromiseTest extends TestCase
         
         $callback = function ($value) use (&$parameter, $exception) {
             $parameter = $value;
-            return Promise::reject($exception);
+            return Promise\reject($exception);
         };
         
         $child = $this->promise->then($callback, $this->createCallback(0));
         
         $this->resolve($value);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame($value, $parameter);
         $this->assertTrue($child->isRejected());
@@ -868,14 +868,14 @@ class PromiseTest extends TestCase
         
         $callback = function ($exception) use (&$parameter, $value) {
             $parameter = $exception;
-            return Promise::resolve($value);
+            return Promise\resolve($value);
         };
         
         $child = $this->promise->then($this->createCallback(0), $callback);
         
         $this->reject($exception);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame($exception, $parameter);
         $this->assertTrue($child->isFulfilled());
@@ -893,14 +893,14 @@ class PromiseTest extends TestCase
         
         $callback = function ($exception) use (&$parameter, $exception2) {
             $parameter = $exception;
-            return Promise::reject($exception2);
+            return Promise\reject($exception2);
         };
         
         $child = $this->promise->then($this->createCallback(0), $callback);
         
         $this->reject($exception1);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame($exception1, $parameter);
         $this->assertTrue($child->isRejected());
@@ -909,7 +909,7 @@ class PromiseTest extends TestCase
     
     /**
      * @depends testRejectCallable
-     * @expectedException Icicle\Promise\Exception\LogicException
+     * @expectedException \Icicle\Promise\Exception\LogicException
      */
     public function testDoneNoOnRejectedThrowsUncatchableExceptionWithRejectionAfter()
     {
@@ -919,12 +919,12 @@ class PromiseTest extends TestCase
         
         $this->reject($exception);
         
-        Loop::run(); // Exception will be thrown from loop.
+        Loop\run(); // Exception will be thrown from loop.
     }
     
     /**
      * @depends testRejectCallable
-     * @expectedException Icicle\Promise\Exception\LogicException
+     * @expectedException \Icicle\Promise\Exception\LogicException
      */
     public function testDoneNoOnRejectedThrowsUncatchableExceptionWithRejectionBefore()
     {
@@ -934,7 +934,7 @@ class PromiseTest extends TestCase
         
         $this->promise->done($this->createCallback(0));
         
-        Loop::run(); // Exception will be thrown from loop.
+        Loop\run(); // Exception will be thrown from loop.
     }
     
     /**
@@ -945,7 +945,7 @@ class PromiseTest extends TestCase
     {
         $this->resolve();
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($this->promise->isFulfilled());
         
@@ -962,7 +962,7 @@ class PromiseTest extends TestCase
         
         $string .= '<after>';
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame('<before><after><onFulfilled><onFulfilled>', $string);
     }
@@ -975,7 +975,7 @@ class PromiseTest extends TestCase
     {
         $this->reject(new Exception());
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($this->promise->isRejected());
         
@@ -992,13 +992,13 @@ class PromiseTest extends TestCase
         
         $string .= '<after>';
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame('<before><after><onRejected><onRejected>', $string);
     }
     
     /**
-     * @expectedException Icicle\Promise\Exception\UnresolvedException
+     * @expectedException \Icicle\Promise\Exception\UnresolvedException
      */
     public function testGettingResultBeforeResolution()
     {
@@ -1020,7 +1020,7 @@ class PromiseTest extends TestCase
         
         $this->reject($exception);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($child->isFulfilled());
         $this->assertNull($child->getResult());
@@ -1041,7 +1041,7 @@ class PromiseTest extends TestCase
         $exception = new RuntimeException();
         $this->reject($exception);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($child1->isRejected());
         $this->assertSame($exception, $child1->getResult());
@@ -1062,7 +1062,7 @@ class PromiseTest extends TestCase
         $callback->method('__invoke')
             ->with($this->isInstanceOf('Icicle\Promise\Exception\CancelledException'));
         
-        $promise = new Promise(function () {}, $callback);
+        $promise = new Promise\Promise(function () {}, $callback);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -1072,7 +1072,7 @@ class PromiseTest extends TestCase
         
         $promise->cancel();
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -1086,7 +1086,7 @@ class PromiseTest extends TestCase
             throw $exception;
         };
         
-        $promise = new Promise(function () {}, $onCancelled);
+        $promise = new Promise\Promise(function () {}, $onCancelled);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -1096,7 +1096,7 @@ class PromiseTest extends TestCase
         
         $promise->cancel();
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($promise->isRejected());
         $this->assertSame($exception, $promise->getResult());
@@ -1113,7 +1113,7 @@ class PromiseTest extends TestCase
         $callback->method('__invoke')
             ->with($this->identicalTo($exception));
         
-        $promise = new Promise(function () {}, $callback);
+        $promise = new Promise\Promise(function () {}, $callback);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -1123,7 +1123,7 @@ class PromiseTest extends TestCase
         
         $promise->cancel($exception);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -1137,7 +1137,7 @@ class PromiseTest extends TestCase
         $callback->method('__invoke')
             ->with($this->isInstanceOf('Icicle\Promise\Exception\CancelledException'));
         
-        $promise = new Promise(function () {}, $callback);
+        $promise = new Promise\Promise(function () {}, $callback);
         
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -1147,7 +1147,7 @@ class PromiseTest extends TestCase
         
         $promise->cancel($reason);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertSame($reason, $promise->getResult()->getReason());
     }
@@ -1166,7 +1166,7 @@ class PromiseTest extends TestCase
         
         $this->promise->cancel();
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($this->promise->isRejected());
         $this->assertTrue($child->isRejected());
@@ -1181,7 +1181,7 @@ class PromiseTest extends TestCase
         
         $child->cancel();
         
-        Loop::run();
+        Loop\run();
         
         $this->assertFalse($this->promise->isPending());
         $this->assertTrue($this->promise->isRejected());
@@ -1198,7 +1198,7 @@ class PromiseTest extends TestCase
         
         $child1->cancel();
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($this->promise->isPending());
         $this->assertTrue($child1->isRejected());
@@ -1216,7 +1216,7 @@ class PromiseTest extends TestCase
         $child1->cancel();
         $child2->cancel();
         
-        Loop::run();
+        Loop\run();
         
         $this->assertFalse($this->promise->isPending());
         $this->assertTrue($child1->isRejected());
@@ -1233,7 +1233,7 @@ class PromiseTest extends TestCase
         
         $this->promise->cancel();
         
-        Loop::run();
+        Loop\run();
         
         $this->assertFalse($this->promise->isPending());
         $this->assertTrue($child1->isRejected());
@@ -1253,7 +1253,7 @@ class PromiseTest extends TestCase
 
         $child3 = $this->promise->then();
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($this->promise->isPending());
         $this->assertTrue($child3->isPending());
@@ -1266,13 +1266,13 @@ class PromiseTest extends TestCase
     {
         $exception = new Exception();
         
-        $promise = new Promise(function () {});
+        $promise = new Promise\Promise(function () {});
         
         $this->resolve($promise);
         
         $this->promise->cancel($exception);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($promise->isRejected());
         $this->assertSame($exception, $promise->getResult());
@@ -1290,7 +1290,7 @@ class PromiseTest extends TestCase
         
         $this->resolve($value);
         
-        $this->assertRunTimeGreaterThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeGreaterThan('Icicle\Loop\run', $time);
         
         $this->assertTrue($delayed->isFulfilled());
         $this->assertSame($value, $delayed->getResult());
@@ -1308,7 +1308,7 @@ class PromiseTest extends TestCase
         
         $this->reject($exception);
         
-        $this->assertRunTimeLessThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeLessThan('Icicle\Loop\run', $time);
         
         $this->assertTrue($delayed->isRejected());
         $this->assertSame($exception, $delayed->getResult());
@@ -1326,7 +1326,7 @@ class PromiseTest extends TestCase
         
         $delayed = $this->promise->delay($time);
         
-        $this->assertRunTimeGreaterThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeGreaterThan('Icicle\Loop\run', $time);
         
         $this->assertTrue($delayed->isFulfilled());
         $this->assertSame($value, $delayed->getResult());
@@ -1344,7 +1344,7 @@ class PromiseTest extends TestCase
         
         $delayed = $this->promise->delay($time);
         
-        $this->assertRunTimeLessThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeLessThan('Icicle\Loop\run', $time);
         
         $this->assertTrue($delayed->isRejected());
         $this->assertSame($exception, $delayed->getResult());
@@ -1358,7 +1358,7 @@ class PromiseTest extends TestCase
         $value = 'test';
         $time = 0.1;
         
-        $promise = new Promise(function ($resolve) use (&$pendingResolve) {
+        $promise = new Promise\Promise(function ($resolve) use (&$pendingResolve) {
             $pendingResolve = $resolve;
         });
         
@@ -1368,7 +1368,7 @@ class PromiseTest extends TestCase
         
         $pendingResolve($value);
         
-        $this->assertRunTimeGreaterThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeGreaterThan('Icicle\Loop\run', $time);
         
         $this->assertTrue($delayed->isFulfilled());
         $this->assertSame($value, $delayed->getResult());
@@ -1387,7 +1387,7 @@ class PromiseTest extends TestCase
         
         $this->resolve($value);
         
-        Loop::tick(false);
+        Loop\tick(false);
         
         $delayed->cancel();
         
@@ -1408,7 +1408,7 @@ class PromiseTest extends TestCase
         
         $delayed = $this->promise->delay($time);
         
-        Loop::tick(false);
+        Loop\tick(false);
         
         $delayed->cancel();
         
@@ -1427,7 +1427,7 @@ class PromiseTest extends TestCase
         
         $delayed->cancel();
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($delayed->isRejected());
         $this->assertTrue($this->promise->isRejected());
@@ -1445,7 +1445,7 @@ class PromiseTest extends TestCase
         
         $delayed->cancel();
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($delayed->isRejected());
         $this->assertTrue($this->promise->isPending());
@@ -1465,7 +1465,7 @@ class PromiseTest extends TestCase
         $delayed->cancel();
         $sibling->cancel();
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($delayed->isRejected());
         $this->assertFalse($this->promise->isPending());
@@ -1485,7 +1485,7 @@ class PromiseTest extends TestCase
 
         $sibling = $this->promise->then();
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($delayed->isRejected());
         $this->assertTrue($this->promise->isPending());
@@ -1507,7 +1507,7 @@ class PromiseTest extends TestCase
         
         $timeout->done($this->createCallback(0), $callback);
         
-        $this->assertRunTimeGreaterThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeGreaterThan('Icicle\Loop\run', $time);
         
         $this->assertTrue($this->promise->isRejected());
         $this->assertInstanceOf('Icicle\Promise\Exception\TimeoutException', $this->promise->getResult());
@@ -1529,7 +1529,7 @@ class PromiseTest extends TestCase
         
         $timeout->done($this->createCallback(0), $callback);
         
-        $this->assertRunTimeGreaterThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeGreaterThan('Icicle\Loop\run', $time);
     }
     
     /**
@@ -1548,7 +1548,7 @@ class PromiseTest extends TestCase
         
         $timeout->done($this->createCallback(0), $callback);
         
-        $this->assertRunTimeGreaterThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeGreaterThan('Icicle\Loop\run', $time);
         
         $this->assertSame($reason, $this->promise->getResult()->getReason());
         $this->assertSame($reason, $timeout->getResult()->getReason());
@@ -1566,7 +1566,7 @@ class PromiseTest extends TestCase
         
         $this->resolve($value);
         
-        $this->assertRunTimeLessThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeLessThan('Icicle\Loop\run', $time);
         
         $this->assertTrue($timeout->isFulfilled());
         $this->assertSame($value, $timeout->getResult());
@@ -1584,7 +1584,7 @@ class PromiseTest extends TestCase
         
         $this->reject($exception);
         
-        $this->assertRunTimeLessThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeLessThan('Icicle\Loop\run', $time);
         
         $this->assertTrue($timeout->isRejected());
         $this->assertSame($exception, $timeout->getResult());
@@ -1602,7 +1602,7 @@ class PromiseTest extends TestCase
         
         $timeout = $this->promise->timeout($time);
         
-        $this->assertRunTimeLessThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeLessThan('Icicle\Loop\run', $time);
         
         $this->assertTrue($timeout->isFulfilled());
         $this->assertSame($value, $timeout->getResult());
@@ -1620,7 +1620,7 @@ class PromiseTest extends TestCase
         
         $timeout = $this->promise->timeout($time);
         
-        $this->assertRunTimeLessThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeLessThan('Icicle\Loop\run', $time);
         
         $this->assertTrue($timeout->isRejected());
         $this->assertSame($exception, $timeout->getResult());
@@ -1638,7 +1638,7 @@ class PromiseTest extends TestCase
         
         $timeout->cancel();
         
-        $this->assertRunTimeLessThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeLessThan('Icicle\Loop\run', $time);
         
         $this->assertTrue($timeout->isRejected());
         $this->assertTrue($this->promise->isRejected());
@@ -1656,7 +1656,7 @@ class PromiseTest extends TestCase
         
         $timeout->cancel();
         
-        $this->assertRunTimeLessThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeLessThan('Icicle\Loop\run', $time);
         
         $this->assertTrue($timeout->isRejected());
         $this->assertTrue($this->promise->isPending());
@@ -1676,7 +1676,7 @@ class PromiseTest extends TestCase
         $timeout->cancel();
         $sibling->cancel();
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($timeout->isRejected());
         $this->assertFalse($this->promise->isPending());
@@ -1696,7 +1696,7 @@ class PromiseTest extends TestCase
 
         $sibling = $this->promise->then();
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($timeout->isRejected());
         $this->assertTrue($this->promise->isPending());
@@ -1718,7 +1718,7 @@ class PromiseTest extends TestCase
 
         $this->resolve($value);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($child->isFulfilled());
         $this->assertSame($value, $child->getResult());
@@ -1735,7 +1735,7 @@ class PromiseTest extends TestCase
 
         $this->reject($exception);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($child->isRejected());
         $this->assertSame($exception, $child->getResult());
@@ -1751,14 +1751,14 @@ class PromiseTest extends TestCase
         $time = 0.1;
 
         $callback = function () use ($time) {
-            return Promise::resolve()->delay($time);
+            return Promise\resolve()->delay($time);
         };
 
         $child = $this->promise->tap($callback);
 
         $this->resolve($value);
 
-        $this->assertRunTimeGreaterThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeGreaterThan('Icicle\Loop\run', $time);
 
         $this->assertTrue($child->isFulfilled());
         $this->assertSame($value, $child->getResult());
@@ -1773,14 +1773,14 @@ class PromiseTest extends TestCase
         $exception = new Exception();
 
         $callback = function () use ($exception) {
-            return Promise::reject($exception);
+            return Promise\reject($exception);
         };
 
         $child = $this->promise->tap($callback);
 
         $this->resolve($value);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($child->isRejected());
         $this->assertSame($exception, $child->getResult());
@@ -1802,7 +1802,7 @@ class PromiseTest extends TestCase
 
         $this->resolve($value);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($child->isRejected());
         $this->assertSame($exception, $child->getResult());
@@ -1819,7 +1819,7 @@ class PromiseTest extends TestCase
 
         $this->resolve($value);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($child->isFulfilled());
         $this->assertSame($value, $child->getResult());
@@ -1836,7 +1836,7 @@ class PromiseTest extends TestCase
 
         $this->reject($exception);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($child->isRejected());
         $this->assertSame($exception, $child->getResult());
@@ -1852,14 +1852,14 @@ class PromiseTest extends TestCase
         $time = 0.1;
 
         $callback = function () use ($time) {
-            return Promise::resolve()->delay($time);
+            return Promise\resolve()->delay($time);
         };
 
         $child = $this->promise->cleanup($callback);
 
         $this->resolve($value);
 
-        $this->assertRunTimeGreaterThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeGreaterThan('Icicle\Loop\run', $time);
 
         $this->assertTrue($child->isFulfilled());
         $this->assertSame($value, $child->getResult());
@@ -1874,14 +1874,14 @@ class PromiseTest extends TestCase
         $exception = new Exception();
 
         $callback = function () use ($exception) {
-            return Promise::reject($exception);
+            return Promise\reject($exception);
         };
 
         $child = $this->promise->cleanup($callback);
 
         $this->resolve($value);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($child->isRejected());
         $this->assertSame($exception, $child->getResult());
@@ -1903,7 +1903,7 @@ class PromiseTest extends TestCase
 
         $this->resolve($value);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($child->isRejected());
         $this->assertSame($exception, $child->getResult());
@@ -1919,14 +1919,14 @@ class PromiseTest extends TestCase
         $time = 0.1;
 
         $callback = function () use ($time) {
-            return Promise::resolve()->delay($time);
+            return Promise\resolve()->delay($time);
         };
 
         $child = $this->promise->cleanup($callback);
 
         $this->reject($exception);
 
-        $this->assertRunTimeGreaterThan(['Icicle\Loop\Loop', 'run'], $time);
+        $this->assertRunTimeGreaterThan('Icicle\Loop\run', $time);
 
         $this->assertTrue($child->isRejected());
         $this->assertSame($exception, $child->getResult());
@@ -1941,14 +1941,14 @@ class PromiseTest extends TestCase
         $exception = new Exception();
 
         $callback = function () use ($exception) {
-            return Promise::reject($exception);
+            return Promise\reject($exception);
         };
 
         $child = $this->promise->cleanup($callback);
 
         $this->reject();
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($child->isRejected());
         $this->assertSame($exception, $child->getResult());
@@ -1969,7 +1969,7 @@ class PromiseTest extends TestCase
 
         $this->reject();
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($child->isRejected());
         $this->assertSame($exception, $child->getResult());
@@ -1987,7 +1987,7 @@ class PromiseTest extends TestCase
 
         $this->resolve($values);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($child->isFulfilled());
     }
@@ -2024,7 +2024,7 @@ class PromiseTest extends TestCase
 
         $this->resolve($value);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($child->isRejected());
     }
@@ -2042,7 +2042,7 @@ class PromiseTest extends TestCase
 
         $this->reject($exception);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($child->isRejected());
         $this->assertSame($exception, $child->getResult());
@@ -2066,7 +2066,7 @@ class PromiseTest extends TestCase
 
         $this->resolve($traversable());
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($child->isFulfilled());
     }

--- a/tests/Socket/Client/ClientTest.php
+++ b/tests/Socket/Client/ClientTest.php
@@ -2,8 +2,8 @@
 namespace Icicle\Tests\Socket\Client;
 
 use Exception;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Socket\Client\Client;
 use Icicle\Tests\TestCase;
 
@@ -47,8 +47,8 @@ class ClientTest extends TestCase
             $this->fail("Could not connect to {$uri}; Errno: {$errno}; {$errstr}");
         }
         
-        return new Promise(function ($resolve, $reject) use ($socket) {
-            $await = Loop::await($socket, function ($resource, $expired) use (&$await, $resolve, $reject) {
+        return new Promise\Promise(function ($resolve, $reject) use ($socket) {
+            $await = Loop\await($socket, function ($resource, $expired) use (&$await, $resolve, $reject) {
                 $await->free();
                 $resolve(new Client($resource));
             });
@@ -106,7 +106,7 @@ class ClientTest extends TestCase
     
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
     
     public function testInvalidSocketType()
@@ -143,7 +143,7 @@ class ClientTest extends TestCase
         
         $promise->done($this->createCallback(1));
         
-        Loop::run();
+        Loop\run();
         
         fclose($server);
         unlink($path);
@@ -169,7 +169,7 @@ class ClientTest extends TestCase
             ->then(function (Client $client) {
                 $promise1 = $client->enableCrypto(STREAM_CRYPTO_METHOD_TLS_CLIENT, self::TIMEOUT);
                 $promise2 = $client->enableCrypto(STREAM_CRYPTO_METHOD_TLS_CLIENT, self::TIMEOUT);
-                return Promise::join([$promise1, $promise2]);
+                return Promise\join([$promise1, $promise2]);
             });
 
         $callback = $this->createCallback(1);
@@ -178,7 +178,7 @@ class ClientTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
 
         fclose($server);
         unlink($path);
@@ -207,9 +207,9 @@ class ClientTest extends TestCase
                 return $client->enableCrypto(STREAM_CRYPTO_METHOD_TLS_CLIENT, self::TIMEOUT);
             });
 
-        Loop::tick(); // Run a few ticks to move into the enable crypto loop.
-        Loop::tick();
-        Loop::tick();
+        Loop\tick(); // Run a few ticks to move into the enable crypto loop.
+        Loop\tick();
+        Loop\tick();
 
         $promise->cancel($exception);
 
@@ -219,7 +219,7 @@ class ClientTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
 
         fclose($server);
         unlink($path);
@@ -254,7 +254,7 @@ class ClientTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
 
         fclose($server);
         unlink($path);
@@ -289,7 +289,7 @@ class ClientTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
 
         fclose($server);
         unlink($path);
@@ -323,7 +323,7 @@ class ClientTest extends TestCase
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         fclose($server);
         unlink($path);

--- a/tests/Socket/Client/ConnectorTest.php
+++ b/tests/Socket/Client/ConnectorTest.php
@@ -1,8 +1,7 @@
 <?php
 namespace Icicle\Tests\Socket\Client;
 
-use Exception;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Socket\Client\Client;
 use Icicle\Socket\Client\Connector;
 use Icicle\Tests\TestCase;
@@ -152,7 +151,7 @@ class ConnectorTest extends TestCase
     
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
     
     public function testConnect()
@@ -175,7 +174,7 @@ class ConnectorTest extends TestCase
             $this->assertSame($client->getRemotePort(), self::PORT);
         });
         
-        Loop::run();
+        Loop\run();
         
         fclose($server);
     }
@@ -203,7 +202,7 @@ class ConnectorTest extends TestCase
             $this->assertSame($client->getRemotePort(), self::PORT);
         });
         
-        Loop::run();
+        Loop\run();
         
         fclose($server);
     }
@@ -229,7 +228,7 @@ class ConnectorTest extends TestCase
             $this->assertSame(null, $client->getRemotePort());
         });
 
-        Loop::run();
+        Loop\run();
 
         fclose($server);
         unlink(self::HOST_UNIX);
@@ -249,7 +248,7 @@ class ConnectorTest extends TestCase
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -266,7 +265,7 @@ class ConnectorTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -287,7 +286,7 @@ class ConnectorTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         fclose($server);
 
@@ -308,7 +307,7 @@ class ConnectorTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
 
         fclose($server);
     }
@@ -355,7 +354,7 @@ class ConnectorTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         fclose($server);
         unlink($path);
@@ -402,7 +401,7 @@ class ConnectorTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
 
         fclose($server);
         unlink($path);
@@ -449,7 +448,7 @@ class ConnectorTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
 
         fclose($server);
         unlink($path);

--- a/tests/Socket/Datagram/DatagramFactoryTest.php
+++ b/tests/Socket/Datagram/DatagramFactoryTest.php
@@ -2,7 +2,7 @@
 namespace Icicle\Tests\Socket\Datagram;
 
 use Exception;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Socket\Datagram\Datagram;
 use Icicle\Socket\Datagram\DatagramFactory;
 use Icicle\Socket\Socket;
@@ -30,7 +30,7 @@ class DatagramFactoryTest extends TestCase
     
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
         
         if ($this->datagram instanceof Datagram) {
             $this->datagram->close();

--- a/tests/Socket/Datagram/DatagramTest.php
+++ b/tests/Socket/Datagram/DatagramTest.php
@@ -2,9 +2,8 @@
 namespace Icicle\Tests\Socket\Datagram;
 
 use Exception;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Socket\Datagram\Datagram;
-use Icicle\Socket\Socket;
 use Icicle\Tests\TestCase;
 
 class DatagramTest extends TestCase
@@ -22,7 +21,7 @@ class DatagramTest extends TestCase
     
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
         
         if ($this->datagram instanceof Datagram) {
             $this->datagram->close();
@@ -110,7 +109,7 @@ class DatagramTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testReceiveFromIPv6()
@@ -143,7 +142,7 @@ class DatagramTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -163,7 +162,7 @@ class DatagramTest extends TestCase
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -183,7 +182,7 @@ class DatagramTest extends TestCase
         
         $this->datagram->close();
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -227,7 +226,7 @@ class DatagramTest extends TestCase
         
         $promise2->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -265,7 +264,7 @@ class DatagramTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -300,7 +299,7 @@ class DatagramTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -334,7 +333,7 @@ class DatagramTest extends TestCase
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $promise = $this->datagram->receive();
         
@@ -350,7 +349,7 @@ class DatagramTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -362,7 +361,7 @@ class DatagramTest extends TestCase
         
         $promise = $this->datagram->receive();
         
-        Loop::tick();
+        Loop\tick();
         
         $this->assertTrue($promise->isPending());
     }
@@ -400,7 +399,7 @@ class DatagramTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $string = "This is a string to write.\n";
         
@@ -422,7 +421,7 @@ class DatagramTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -440,7 +439,7 @@ class DatagramTest extends TestCase
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
 
     public function testSend()
@@ -468,7 +467,7 @@ class DatagramTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $data = stream_socket_recvfrom($client, self::CHUNK_SIZE);
         
@@ -505,7 +504,7 @@ class DatagramTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $data = stream_socket_recvfrom($client, self::CHUNK_SIZE);
         
@@ -542,7 +541,7 @@ class DatagramTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $data = stream_socket_recvfrom($client, self::CHUNK_SIZE);
         
@@ -566,7 +565,7 @@ class DatagramTest extends TestCase
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     public function testSendEmptyString()
@@ -592,7 +591,7 @@ class DatagramTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $promise = $this->datagram->send($address, $port, '0');
         
@@ -602,7 +601,7 @@ class DatagramTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $data = stream_socket_recvfrom($client, self::CHUNK_SIZE);
         
@@ -644,7 +643,7 @@ class DatagramTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -682,6 +681,6 @@ class DatagramTest extends TestCase
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Socket/Server/ServerFactoryTest.php
+++ b/tests/Socket/Server/ServerFactoryTest.php
@@ -2,7 +2,7 @@
 namespace Icicle\Tests\Socket\Server;
 
 use Exception;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Socket\Server\Server;
 use Icicle\Socket\Server\ServerFactory;
 use Icicle\Tests\TestCase;
@@ -28,7 +28,7 @@ class ServerFactoryTest extends TestCase
     
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
         
         if ($this->server instanceof Server) {
             $this->server->close();
@@ -126,7 +126,7 @@ class ServerFactoryTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         unlink($path);
     }

--- a/tests/Socket/Server/ServerTest.php
+++ b/tests/Socket/Server/ServerTest.php
@@ -2,7 +2,7 @@
 namespace Icicle\Tests\Socket\Server;
 
 use Exception;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Socket\Server\Server;
 use Icicle\Tests\TestCase;
 
@@ -20,7 +20,7 @@ class ServerTest extends TestCase
     
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
         
         if ($this->server instanceof Server) {
             $this->server->close();
@@ -76,7 +76,7 @@ class ServerTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
 
         fclose($client);
     }
@@ -98,7 +98,7 @@ class ServerTest extends TestCase
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -118,7 +118,7 @@ class ServerTest extends TestCase
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -140,7 +140,7 @@ class ServerTest extends TestCase
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -174,7 +174,7 @@ class ServerTest extends TestCase
         
         $promise2->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
 
         fclose($client);
     }
@@ -208,6 +208,6 @@ class ServerTest extends TestCase
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Socket/Stream/ReadableSocketTestTrait.php
+++ b/tests/Socket/Stream/ReadableSocketTestTrait.php
@@ -1,8 +1,8 @@
 <?php
 namespace Icicle\Tests\Socket\Stream;
 
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 
 trait ReadableSocketTestTrait
 {
@@ -25,7 +25,7 @@ trait ReadableSocketTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run(); // Drain readable buffer.
+        Loop\run(); // Drain readable buffer.
 
         $promise = $readable->read();
 
@@ -35,7 +35,7 @@ trait ReadableSocketTestTrait
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run(); // Should get an empty string.
+        Loop\run(); // Should get an empty string.
 
         $promise = $readable->read();
 
@@ -45,7 +45,7 @@ trait ReadableSocketTestTrait
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run(); // Should reject with UnreadableException.
+        Loop\run(); // Should reject with UnreadableException.
     }
 
     /**
@@ -65,7 +65,7 @@ trait ReadableSocketTestTrait
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $promise = $readable->read();
 
@@ -75,7 +75,7 @@ trait ReadableSocketTestTrait
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run(); // Should reject with UnreadableException.
+        Loop\run(); // Should reject with UnreadableException.
     }
     
     /**
@@ -97,7 +97,7 @@ trait ReadableSocketTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run(); // Drain readable buffer.
+        Loop\run(); // Drain readable buffer.
 
         $promise = $readable->read(null, "\0");
 
@@ -107,7 +107,7 @@ trait ReadableSocketTestTrait
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run(); // Should get an empty string.
+        Loop\run(); // Should get an empty string.
 
         $promise = $readable->read(null, "\0");
         
@@ -117,7 +117,7 @@ trait ReadableSocketTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run(); // Should reject with UnreadableException.
+        Loop\run(); // Should reject with UnreadableException.
     }
     
     /**
@@ -135,7 +135,7 @@ trait ReadableSocketTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -153,7 +153,7 @@ trait ReadableSocketTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -174,7 +174,7 @@ trait ReadableSocketTestTrait
              ->method('write')
              ->will($this->returnCallback(function ($data) {
                  $this->assertSame(StreamTest::WRITE_STRING, $data);
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
         
         $mock->expects($this->never())
@@ -188,7 +188,7 @@ trait ReadableSocketTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($readable->isOpen());
     }
@@ -212,7 +212,7 @@ trait ReadableSocketTestTrait
         $mock->expects($this->once())
              ->method('write')
              ->will($this->returnCallback(function ($data) use ($length) {
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
         
         $mock->expects($this->never())
@@ -226,7 +226,7 @@ trait ReadableSocketTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($readable->isOpen());
     }
@@ -249,7 +249,7 @@ trait ReadableSocketTestTrait
              ->method('write')
              ->will($this->returnCallback(function ($data) {
                  $this->assertSame(StreamTest::WRITE_STRING, $data);
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
         
         $mock->expects($this->never())
@@ -263,7 +263,7 @@ trait ReadableSocketTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($readable->isOpen());
     }
@@ -287,7 +287,7 @@ trait ReadableSocketTestTrait
         $mock->expects($this->once())
              ->method('write')
              ->will($this->returnCallback(function ($data) use ($length) {
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
         
         $mock->expects($this->never())
@@ -301,7 +301,7 @@ trait ReadableSocketTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $this->assertTrue($readable->isOpen());
     }

--- a/tests/Socket/Stream/ReadableStreamTest.php
+++ b/tests/Socket/Stream/ReadableStreamTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace Icicle\Tests\Socket\Stream;
 
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Socket\Stream\ReadableStream;
 use Icicle\Tests\Stream\ReadableStreamTestTrait;
 
@@ -29,13 +29,13 @@ class ReadableStreamTest extends StreamTest
                  ->will($this->returnValue(true));
         
         $writable->method('write')
-                 ->will($this->returnCallback(function ($data) use ($write) {
-                     $length = strlen($data);
-                     if ($length) {
-                        fwrite($write, $data);
-                     }
-                     return Promise::resolve($length);
-                 }));
+            ->will($this->returnCallback(function ($data) use ($write) {
+                $length = strlen($data);
+                if ($length) {
+                    fwrite($write, $data);
+                }
+                return Promise\resolve($length);
+            }));
         
         $writable->method('close')
                  ->will($this->returnCallback(function () use ($write) {

--- a/tests/Socket/Stream/StreamTest.php
+++ b/tests/Socket/Stream/StreamTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Icicle\Tests\Socket\Stream;
 
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Tests\TestCase;
 
 abstract class StreamTest extends TestCase
@@ -17,6 +17,6 @@ abstract class StreamTest extends TestCase
     
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
 }

--- a/tests/Socket/Stream/WritableSocketTestTrait.php
+++ b/tests/Socket/Stream/WritableSocketTestTrait.php
@@ -1,7 +1,7 @@
 <?php
 namespace Icicle\Tests\Socket\Stream;
 
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 
 trait WritableSocketTestTrait
 {
@@ -23,7 +23,7 @@ trait WritableSocketTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -43,6 +43,6 @@ trait WritableSocketTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Socket/Stream/WritableStreamTest.php
+++ b/tests/Socket/Stream/WritableStreamTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace Icicle\Tests\Socket\Stream;
 
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Socket\Stream\WritableStream;
 use Icicle\Tests\Stream\WritableBufferedStreamTestTrait;
 use Icicle\Tests\Stream\WritableStreamTestTrait;
@@ -28,13 +28,13 @@ class WritableStreamTest extends StreamTest
                  ->will($this->returnValue(true));
         
         $readable->method('read')
-                 ->will($this->returnCallback(function ($length = null) use ($read) {
-                     if (null === $length) {
-                         $length = 8192;
-                     }
-                     return Promise::resolve(fread($read, $length));
-                 }));
-        
+            ->will($this->returnCallback(function ($length = null) use ($read) {
+                if (null === $length) {
+                    $length = 8192;
+                }
+                return Promise\resolve(fread($read, $length));
+            }));
+
         $readable->method('close')
                  ->will($this->returnCallback(function () use ($read) {
                      fclose($read);

--- a/tests/Stream/ReadableStreamTestTrait.php
+++ b/tests/Stream/ReadableStreamTestTrait.php
@@ -2,8 +2,8 @@
 namespace Icicle\Tests\Stream;
 
 use Exception;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 
 trait ReadableStreamTestTrait
 {
@@ -26,7 +26,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -48,7 +48,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -68,7 +68,7 @@ trait ReadableStreamTestTrait
         
         $readable->close();
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -96,7 +96,7 @@ trait ReadableStreamTestTrait
         
         $writable->write(StreamTest::WRITE_STRING);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -118,7 +118,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $promise = $readable->read($length);
         
@@ -128,7 +128,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -150,7 +150,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -172,7 +172,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $promise = $readable->read();
         
@@ -186,7 +186,7 @@ trait ReadableStreamTestTrait
         
         $writable->write(StreamTest::WRITE_STRING);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -198,7 +198,7 @@ trait ReadableStreamTestTrait
         
         $promise = $readable->read(); // Nothing to read on this stream.
         
-        Loop::tick();
+        Loop\tick();
         
         $this->assertTrue($promise->isPending());
     }
@@ -220,11 +220,11 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $promise = $readable->read();
         
-        Loop::tick();
+        Loop\tick();
         
         $this->assertTrue($promise->isPending());
         
@@ -244,7 +244,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -267,7 +267,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -291,7 +291,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -315,7 +315,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -337,11 +337,11 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $promise = $readable->read(null, $char);
         
-        Loop::tick();
+        Loop\tick();
         
         $this->assertTrue($promise->isPending());
     }
@@ -363,7 +363,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -385,7 +385,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -405,7 +405,7 @@ trait ReadableStreamTestTrait
         
         $readable->close();
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -433,7 +433,7 @@ trait ReadableStreamTestTrait
         
         $writable->write(StreamTest::WRITE_STRING);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -457,7 +457,7 @@ trait ReadableStreamTestTrait
         
         $writable->write(StreamTest::WRITE_STRING);
         
-        Loop::run();
+        Loop\run();
         
         $promise = $readable->read(null, $char);
         
@@ -467,7 +467,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -492,7 +492,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -516,7 +516,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $promise = $readable->read(null, $char);
         
@@ -530,7 +530,7 @@ trait ReadableStreamTestTrait
         
         $writable->write(StreamTest::WRITE_STRING);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -542,7 +542,7 @@ trait ReadableStreamTestTrait
         
         $promise = $readable->read(null, "\n"); // Nothing to read on this stream.
         
-        Loop::tick();
+        Loop\tick();
         
         $this->assertTrue($promise->isPending());
     }
@@ -560,11 +560,11 @@ trait ReadableStreamTestTrait
         
         $promise = $readable->read();
         
-        Loop::run();
+        Loop\run();
         
         $promise = $readable->read(null, $char);
         
-        Loop::tick();
+        Loop\tick();
         
         $this->assertTrue($promise->isPending());
         
@@ -579,7 +579,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -602,7 +602,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $promise = $readable->read();
         
@@ -612,7 +612,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -637,7 +637,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
         
         $promise = $readable->read();
         
@@ -649,7 +649,7 @@ trait ReadableStreamTestTrait
         
         $writable->write(StreamTest::WRITE_STRING);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -671,23 +671,23 @@ trait ReadableStreamTestTrait
              ->method('write')
              ->will($this->returnCallback(function ($data) {
                  $this->assertSame(StreamTest::WRITE_STRING, $data);
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
         
         $promise = $readable->pipe($mock);
         $writable->write(StreamTest::WRITE_STRING);
         
-        Loop::tick();
+        Loop\tick();
         
         $this->assertTrue($promise->isPending());
         $writable->write(StreamTest::WRITE_STRING);
         
-        Loop::tick();
+        Loop\tick();
         
         $this->assertTrue($promise->isPending());
         $writable->write(StreamTest::WRITE_STRING);
         
-        Loop::tick();
+        Loop\tick();
 
         $this->assertFalse($promise->isPending());
         $this->assertTrue($promise->isFulfilled());
@@ -714,7 +714,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -735,7 +735,7 @@ trait ReadableStreamTestTrait
              ->method('write')
              ->will($this->returnCallback(function ($data) {
                  $this->assertSame(StreamTest::WRITE_STRING, $data);
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
         
         $mock->expects($this->once())
@@ -745,13 +745,13 @@ trait ReadableStreamTestTrait
         
         $promise->done($this->createCallback(0), $this->createCallback(1));
         
-        Loop::tick();
+        Loop\tick();
         
         $this->assertTrue($promise->isPending());
         
         $readable->close();
         
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -772,7 +772,7 @@ trait ReadableStreamTestTrait
             ->method('write')
             ->will($this->returnCallback(function ($data) use ($readable) {
                 $readable->close();
-                return Promise::resolve(strlen($data));
+                return Promise\resolve(strlen($data));
             }));
 
         $mock->expects($this->once())
@@ -786,7 +786,7 @@ trait ReadableStreamTestTrait
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::tick();
+        Loop\tick();
     }
     
     /**
@@ -807,7 +807,7 @@ trait ReadableStreamTestTrait
              ->method('write')
              ->will($this->returnCallback(function ($data) {
                  $this->assertSame(StreamTest::WRITE_STRING, $data);
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
         
         $mock->expects($this->never())
@@ -817,13 +817,13 @@ trait ReadableStreamTestTrait
         
         $promise->done($this->createCallback(0), $this->createCallback(1));
         
-        Loop::tick();
+        Loop\tick();
         
         $this->assertTrue($promise->isPending());
         
         $readable->close();
         
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -844,7 +844,7 @@ trait ReadableStreamTestTrait
             ->method('write')
             ->will($this->returnCallback(function ($data) use ($readable) {
                 $readable->close();
-                return Promise::resolve(strlen($data));
+                return Promise\resolve(strlen($data));
             }));
 
         $mock->expects($this->never())
@@ -858,7 +858,7 @@ trait ReadableStreamTestTrait
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::tick();
+        Loop\tick();
     }
     
     /**
@@ -879,7 +879,7 @@ trait ReadableStreamTestTrait
              ->method('write')
              ->will($this->returnCallback(function ($data) {
                  $this->assertSame(StreamTest::WRITE_STRING, $data);
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
         
         $mock->expects($this->never())
@@ -895,13 +895,13 @@ trait ReadableStreamTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::tick();
+        Loop\tick();
         
         $this->assertTrue($promise->isPending());
         
         $promise->cancel($exception);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -924,7 +924,7 @@ trait ReadableStreamTestTrait
              ->method('write')
              ->will($this->returnCallback(function ($data) use ($length) {
                  $this->assertSame(substr(StreamTest::WRITE_STRING, 0, $length), $data);
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
         
         $mock->expects($this->never())
@@ -938,7 +938,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::tick();
+        Loop\tick();
         
         $mock = $this->getMockBuilder('Icicle\Stream\WritableStreamInterface')->getMock();
         
@@ -948,7 +948,7 @@ trait ReadableStreamTestTrait
         $mock->expects($this->exactly(2))
              ->method('write')
              ->will($this->returnCallback(function ($data) {
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
         
         $mock->expects($this->never())
@@ -962,13 +962,13 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::tick();
+        Loop\tick();
         
         $this->assertTrue($promise->isPending());
         
         $writable->write(StreamTest::WRITE_STRING);
         
-        Loop::tick();
+        Loop\tick();
         
         $this->assertFalse($promise->isPending());
     }
@@ -1001,7 +1001,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::tick();
+        Loop\tick();
     }
     
     /**
@@ -1025,7 +1025,7 @@ trait ReadableStreamTestTrait
              ->method('write')
              ->will($this->returnCallback(function ($data) use ($offset) {
                  $this->assertSame(substr(StreamTest::WRITE_STRING, 0, $offset + 1), $data);
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
         
         $promise = $readable->pipe($mock, true, null, $char);
@@ -1036,7 +1036,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -1061,7 +1061,7 @@ trait ReadableStreamTestTrait
              ->method('write')
              ->will($this->returnCallback(function ($data) use ($offset) {
                  $this->assertSame(substr(StreamTest::WRITE_STRING, 0, $offset + 1), $data);
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
         
         $promise = $readable->pipe($mock, true, null, $byte);
@@ -1072,7 +1072,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -1095,7 +1095,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -1120,7 +1120,7 @@ trait ReadableStreamTestTrait
              ->method('write')
              ->will($this->returnCallback(function ($data) use ($offset) {
                  $this->assertSame(substr(StreamTest::WRITE_STRING, 0, $offset + 1), $data);
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
 
         $promise = $readable->pipe($mock, true, null, $string);
@@ -1131,7 +1131,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -1152,7 +1152,7 @@ trait ReadableStreamTestTrait
              ->method('write')
              ->will($this->returnCallback(function ($data) {
                  $this->assertSame(StreamTest::WRITE_STRING, $data);
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
         
         $mock->expects($this->once())
@@ -1162,13 +1162,13 @@ trait ReadableStreamTestTrait
         
         $promise->done($this->createCallback(0), $this->createCallback(1));
         
-        Loop::tick();
+        Loop\tick();
         
         $this->assertTrue($promise->isPending());
         
         $readable->close();
         
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -1189,7 +1189,7 @@ trait ReadableStreamTestTrait
             ->method('write')
             ->will($this->returnCallback(function ($data) use ($readable) {
                 $readable->close();
-                return Promise::resolve(strlen($data));
+                return Promise\resolve(strlen($data));
             }));
 
         $mock->expects($this->once())
@@ -1203,7 +1203,7 @@ trait ReadableStreamTestTrait
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::tick();
+        Loop\tick();
     }
     
     /**
@@ -1224,7 +1224,7 @@ trait ReadableStreamTestTrait
              ->method('write')
              ->will($this->returnCallback(function ($data) {
                  $this->assertSame(StreamTest::WRITE_STRING, $data);
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
         
         $mock->expects($this->never())
@@ -1234,13 +1234,13 @@ trait ReadableStreamTestTrait
         
         $promise->done($this->createCallback(0), $this->createCallback(1));
         
-        Loop::tick();
+        Loop\tick();
         
         $this->assertTrue($promise->isPending());
         
         $readable->close();
         
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -1261,7 +1261,7 @@ trait ReadableStreamTestTrait
             ->method('write')
             ->will($this->returnCallback(function ($data) use ($readable) {
                 $readable->close();
-                return Promise::resolve(strlen($data));
+                return Promise\resolve(strlen($data));
             }));
 
         $mock->expects($this->never())
@@ -1275,7 +1275,7 @@ trait ReadableStreamTestTrait
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::tick();
+        Loop\tick();
     }
     
     /**
@@ -1300,7 +1300,7 @@ trait ReadableStreamTestTrait
              ->method('write')
              ->will($this->returnCallback(function ($data) use ($length) {
                  $this->assertSame(substr(StreamTest::WRITE_STRING, 0, $length), $data);
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
         
         $mock->expects($this->never())
@@ -1314,7 +1314,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::tick();
+        Loop\tick();
         
         $mock = $this->getMockBuilder('Icicle\Stream\WritableStreamInterface')->getMock();
         
@@ -1325,7 +1325,7 @@ trait ReadableStreamTestTrait
              ->method('write')
              ->will($this->returnCallback(function ($data) use ($offset, $length) {
                  $this->assertSame(substr(StreamTest::WRITE_STRING, $length, $offset - $length + 1), $data);
-                 return Promise::resolve(strlen($data));
+                 return Promise\resolve(strlen($data));
              }));
         
         $mock->expects($this->never())
@@ -1339,7 +1339,7 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::tick();
+        Loop\tick();
         
         $this->assertFalse($promise->isPending());
     }
@@ -1372,6 +1372,6 @@ trait ReadableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::tick();
+        Loop\tick();
     }
 }

--- a/tests/Stream/SinkTest.php
+++ b/tests/Stream/SinkTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Icicle\Tests\Stream;
 
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Stream\Sink;
 use Icicle\Tests\TestCase;
 
@@ -9,7 +9,7 @@ class SinkTest extends TestCase
 {
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
     
     /**
@@ -35,7 +35,7 @@ class SinkTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     public function testEmptySinkIsWritable()
@@ -52,7 +52,7 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertSame(strlen(StreamTest::WRITE_STRING), $sink->getLength());
 
@@ -68,7 +68,7 @@ class SinkTest extends TestCase
     {
         $promise = $sink->seek(0);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
         $this->assertSame(0, $sink->tell());
@@ -81,7 +81,7 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($sink->isReadable());
     }
@@ -97,7 +97,7 @@ class SinkTest extends TestCase
 
         $promise = $sink->seek(0);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
 
@@ -109,7 +109,7 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($sink->isReadable());
         $this->assertSame($length, $sink->tell());
@@ -126,7 +126,7 @@ class SinkTest extends TestCase
 
         $promise = $sink->seek(0);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
 
@@ -138,7 +138,7 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($sink->isReadable());
         $this->assertSame(strlen(StreamTest::WRITE_STRING), $sink->tell());
@@ -153,7 +153,7 @@ class SinkTest extends TestCase
     {
         $promise = $sink->seek(0);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
 
@@ -165,7 +165,7 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($sink->isReadable());
         $this->assertSame(0, $sink->tell());
@@ -180,7 +180,7 @@ class SinkTest extends TestCase
     {
         $promise = $sink->seek(0);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
 
@@ -192,7 +192,7 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($sink->isReadable());
         $this->assertSame(0, $sink->tell());
@@ -210,7 +210,7 @@ class SinkTest extends TestCase
 
         $promise = $sink->seek(0);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
 
@@ -222,7 +222,7 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertTrue($sink->isReadable());
         $this->assertSame($position + 1, $sink->tell());
@@ -237,7 +237,7 @@ class SinkTest extends TestCase
     {
         $promise = $sink->seek(0);
 
-        Loop::run();
+        Loop\run();
 
         $promise = $sink->write(StreamTest::WRITE_STRING);
 
@@ -247,13 +247,13 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
 
         $promise = $sink->seek(0);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
         $this->assertSame(0, $sink->tell());
@@ -266,7 +266,7 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -280,17 +280,17 @@ class SinkTest extends TestCase
 
         $sink->write(StreamTest::WRITE_STRING);
 
-        Loop::run();
+        Loop\run();
 
         $promise = $sink->write($string);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
 
         $promise = $sink->seek(0);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
         $this->assertSame(0, $sink->tell());
@@ -303,7 +303,7 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($sink->isReadable());
     }
@@ -320,7 +320,7 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
         $this->assertFalse($sink->isReadable());
@@ -338,11 +338,11 @@ class SinkTest extends TestCase
 
         $sink->write(StreamTest::WRITE_STRING);
 
-        Loop::run();
+        Loop\run();
 
         $promise = $sink->seek($position);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
         $this->assertSame($position, $sink->tell());
@@ -355,7 +355,7 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($sink->isReadable());
     }
@@ -371,11 +371,11 @@ class SinkTest extends TestCase
 
         $sink->write(StreamTest::WRITE_STRING);
 
-        Loop::run();
+        Loop\run();
 
         $promise = $sink->seek($position);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
         $this->assertSame($position, $sink->tell());
@@ -388,13 +388,13 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertSame($position + strlen(StreamTest::WRITE_STRING), $sink->tell());
 
         $promise = $sink->seek(0);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
         $this->assertSame(0, $sink->tell());
@@ -410,7 +410,7 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($sink->isReadable());
     }
@@ -426,18 +426,18 @@ class SinkTest extends TestCase
 
         $sink->write(StreamTest::WRITE_STRING);
 
-        Loop::run();
+        Loop\run();
 
         $promise = $sink->seek(-$position, SEEK_CUR);
 
         $this->assertFalse($promise->isPending());
         $this->assertSame(strlen(StreamTest::WRITE_STRING) - $position, $sink->tell());
 
-        Loop::run();
+        Loop\run();
 
         $promise = $sink->seek(-$position, SEEK_CUR);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
         $this->assertSame(strlen(StreamTest::WRITE_STRING) - $position * 2, $sink->tell());
@@ -450,7 +450,7 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($sink->isReadable());
     }
@@ -463,11 +463,11 @@ class SinkTest extends TestCase
 
         $sink->write(StreamTest::WRITE_STRING);
 
-        Loop::run();
+        Loop\run();
 
         $promise = $sink->seek(-$position, SEEK_END);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
         $this->assertSame(strlen(StreamTest::WRITE_STRING) - $position, $sink->tell());
@@ -480,7 +480,7 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($sink->isReadable());
     }
@@ -491,7 +491,7 @@ class SinkTest extends TestCase
 
         $sink->write(StreamTest::WRITE_STRING);
 
-        Loop::run();
+        Loop\run();
 
         $promise = $sink->seek(-1);
 
@@ -501,7 +501,7 @@ class SinkTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
 
         $promise = $sink->seek($sink->getLength());
 
@@ -511,7 +511,7 @@ class SinkTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
 
         return $sink;
     }
@@ -531,7 +531,7 @@ class SinkTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -551,7 +551,7 @@ class SinkTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -565,13 +565,13 @@ class SinkTest extends TestCase
 
         $this->assertFalse($sink->isWritable());
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
 
         $promise = $sink->seek(0);
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($promise->isPending());
         $this->assertSame(0, $sink->tell());
@@ -585,7 +585,7 @@ class SinkTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($sink->isReadable());
 
@@ -607,6 +607,6 @@ class SinkTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Stream/StreamTest.php
+++ b/tests/Stream/StreamTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Icicle\Tests\Stream;
 
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Stream\Stream;
 use Icicle\Tests\TestCase;
 
@@ -27,7 +27,7 @@ class StreamTest extends TestCase
     
     public function tearDown()
     {
-        Loop::clear();
+        Loop\clear();
     }
 
     public function testEndWithPendingRead()
@@ -54,7 +54,7 @@ class StreamTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($readable->isReadable());
     }
@@ -86,7 +86,7 @@ class StreamTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($readable->isReadable());
     }

--- a/tests/Stream/WritableBufferedStreamTestTrait.php
+++ b/tests/Stream/WritableBufferedStreamTestTrait.php
@@ -1,7 +1,7 @@
 <?php
 namespace Icicle\Tests\Stream;
 
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 
 trait WritableBufferedStreamTestTrait
 {
@@ -29,7 +29,7 @@ trait WritableBufferedStreamTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -61,7 +61,7 @@ trait WritableBufferedStreamTestTrait
         
         while ($promise->isPending()) {
             $readable->read(); // Pull more data out of the buffer.
-            Loop::tick();
+            Loop\tick();
         }
     }
     
@@ -91,7 +91,7 @@ trait WritableBufferedStreamTestTrait
 
         while ($promise->isPending()) {
             $readable->read(StreamTest::CHUNK_SIZE); // Pull more data out of the buffer.
-            Loop::tick();
+            Loop\tick();
         }
         
         $this->assertFalse($writable->isWritable());
@@ -121,7 +121,7 @@ trait WritableBufferedStreamTestTrait
         
         while ($promise->isPending()) {
             $readable->read(); // Pull more data out of the buffer.
-            Loop::tick();
+            Loop\tick();
         }
     }
     
@@ -143,6 +143,6 @@ trait WritableBufferedStreamTestTrait
         
         $promise->done($this->createCallback(0), $this->createCallback(1));
         
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Stream/WritableStreamTestTrait.php
+++ b/tests/Stream/WritableStreamTestTrait.php
@@ -1,7 +1,7 @@
 <?php
 namespace Icicle\Tests\Stream;
 
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 
 trait WritableStreamTestTrait
 {
@@ -24,7 +24,7 @@ trait WritableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $promise = $readable->read();
         
@@ -34,7 +34,7 @@ trait WritableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -56,7 +56,7 @@ trait WritableStreamTestTrait
         
         $promise->done($this->createCallback(0), $callback);
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -74,7 +74,7 @@ trait WritableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
         
         $promise = $writable->write('0');
         
@@ -92,7 +92,7 @@ trait WritableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
         
-        Loop::run();
+        Loop\run();
     }
     
     /**
@@ -122,7 +122,7 @@ trait WritableStreamTestTrait
         
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
 
         $this->assertFalse($writable->isWritable());
         $this->assertFalse($writable->isOpen());


### PR DESCRIPTION
### New Features
- `Icicle\Socket\Datagram` classes and interfaces added to documentation and can now be used.
### Changes
- The Loop facade class has been replaced by a set of functions defined in the `Icicle\Loop` namespace. Generally, calls to the Loop facade such as `Loop::run()` can be replaced with `Loop\run()` (using `Icicle\Loop` instead of `Icicle\Loop\Loop`). See the [Loop documentation](https://github.com/icicleio/Icicle/wiki/Loop) for more information.
- Static functions in `Icicle\Promise\Promise` have been replaced with functions defined in the `Icicle\Promise` namespace. Calls such as `Promise::resolve()` can be replace with `Promise\resolve()` (using `Icicle\Promise` instead of `Icicle\Promise\Promise`). See the [Promises documentation](https://github.com/icicleio/Icicle/wiki/Promises) for more information.
- Static functions in `Icicle\Coroutine\Coroutine` have been replaced with functions defined in the `Icicle\Coroutine` namespace. Like promises above, calls such as `Coroutine::async()` can be replaced with `Coroutine\async()` (using `Icicle\Coroutine` instead of `Icicle\Coroutine\Coroutine`). See the [Coroutine documentation](https://github.com/icicleio/Icicle/wiki/Coroutine) for more information.
- Lazy promises should now be created with the function `Icicle\Promise\lazy()` instead of directly constructing a `LazyPromise` instance. `Icicle\Promise\LazyPromise` has been moved to `Icicle\Promise\Structures\LazyPromise` and should not be created directly, but rather is an implementation detail of `Icicle\Promise\lazy()`.
- The promise returned from `Icicle\Socket\Server\Server::accept()` will no longer be rejected with an `AcceptException` if accepting the client fails. The timeout option was also removed from this method, as retrying after a failed accept would make the timeout unreliable.
- Removed tests from distributions after updating other components to no longer depend on test classes from this package. Use the `--prefer-source` option when installing with Composer if you wish to have tests included.
### Bug Fixes
- Updated stream closing methods to avoid constructing an exception object if there are no pending promises to be rejected.

---
### Notes

Documentation is still being updated for these changes, but will be completed before merging.

Moving from static functions to namespaced regular functions is a major API change, but most code can be updated with a simple find and replace. For example, replacing `Promise::resolve(...)` with `Promise\resolve(...)` and altering namespaces in `use` statements from `Icicle\Promise\Promise` to `Icicle\Promise`. Most code should only take a few minutes to update.
