### PR TITLE
Fixed version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0-dev"
+        "php": "~7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.0.x-dev"
+        "phpunit/phpunit": "~5.0"
     },
     "minimum-stability": "dev",
     "suggest": {


### PR DESCRIPTION
It's always better to use actual version constraints instead of branch names.
